### PR TITLE
Introduce ItemEntity bridge usage

### DIFF
--- a/Incomes/Sources/AppIntent/Model/ItemEntity.swift
+++ b/Incomes/Sources/AppIntent/Model/ItemEntity.swift
@@ -8,7 +8,7 @@
 
 import AppIntents
 
-struct ItemEntity: AppEntity {
+struct ItemEntity: AppEntity, ModelBridgeable {
     static let defaultQuery = ItemEntityQuery()
 
     static var typeDisplayRepresentation: TypeDisplayRepresentation {
@@ -38,6 +38,7 @@ struct ItemEntity: AppEntity {
     let outgo: Decimal
     let profit: Decimal
     let balance: Decimal
+    let category: String?
 
     init(_ item: Item) throws {
         id = try item.id.base64Encoded()
@@ -47,5 +48,18 @@ struct ItemEntity: AppEntity {
         outgo = item.outgo
         profit = item.profit
         balance = item.balance
+        category = item.category?.displayName
+    }
+}
+
+extension ItemEntity {
+    var persistentIdentifier: Item.ID? { try? .init(base64Encoded: id) }
+}
+
+extension ItemEntity {
+    typealias Model = Item
+
+    init?(_ model: Item) {
+        try? self.init(model)
     }
 }

--- a/Incomes/Sources/Item/Component/Chart/BalanceChartSection.swift
+++ b/Incomes/Sources/Item/Component/Chart/BalanceChartSection.swift
@@ -11,12 +11,12 @@ import SwiftUI
 import SwiftUtilities
 
 struct BalanceChartSection {
-    @Query private var items: [Item]
+    @BridgeQuery private var items: [ItemEntity]
 
     @State private var isPresented = false
 
     init(_ descriptor: FetchDescriptor<Item>) {
-        _items = .init(descriptor)
+        _items = .init(Query(descriptor))
     }
 }
 
@@ -81,11 +81,11 @@ private extension BalanceChartSection {
         }
     }
 
-    func date(of item: Item) -> Date {
+    func date(of item: ItemEntity) -> Date {
         item.localDate
     }
 
-    func balance(of item: Item) -> Decimal {
+    func balance(of item: ItemEntity) -> Decimal {
         item.balance
     }
 }

--- a/Incomes/Sources/Item/Component/Chart/CategoryChartSection.swift
+++ b/Incomes/Sources/Item/Component/Chart/CategoryChartSection.swift
@@ -10,10 +10,10 @@ import SwiftData
 import SwiftUI
 
 struct CategoryChartSection {
-    @Query private var items: [Item]
+    @BridgeQuery private var items: [ItemEntity]
 
     init(_ descriptor: FetchDescriptor<Item>) {
-        _items = .init(descriptor)
+        _items = .init(Query(descriptor))
     }
 }
 
@@ -24,10 +24,7 @@ extension CategoryChartSection: View {
                 Dictionary(
                     grouping: items.filter(\.income.isNotZero)
                 ) {
-                    guard let category = $0.category else {
-                        return "Others"
-                    }
-                    return category.displayName
+                    $0.category ?? "Others"
                 }.map { displayName, items in
                     (
                         title: displayName,
@@ -56,10 +53,7 @@ extension CategoryChartSection: View {
                 Dictionary(
                     grouping: items.filter(\.outgo.isNotZero)
                 ) {
-                    guard let category = $0.category else {
-                        return "Others"
-                    }
-                    return category.displayName
+                    $0.category ?? "Others"
                 }.map { displayName, items in
                     (
                         title: displayName,

--- a/Incomes/Sources/Item/Component/Chart/IncomeAndOutgoChartSection.swift
+++ b/Incomes/Sources/Item/Component/Chart/IncomeAndOutgoChartSection.swift
@@ -11,12 +11,12 @@ import SwiftUI
 import SwiftUtilities
 
 struct IncomeAndOutgoChartSection {
-    @Query private var items: [Item]
+    @BridgeQuery private var items: [ItemEntity]
 
     @State private var isPresented = false
 
     init(_ descriptor: FetchDescriptor<Item>) {
-        _items = .init(descriptor)
+        _items = .init(Query(descriptor))
     }
 }
 
@@ -84,15 +84,15 @@ private extension IncomeAndOutgoChartSection {
         }
     }
 
-    func date(of item: Item) -> Date {
+    func date(of item: ItemEntity) -> Date {
         item.localDate
     }
 
-    func income(of item: Item) -> Decimal {
+    func income(of item: ItemEntity) -> Decimal {
         item.income
     }
 
-    func outgo(of item: Item) -> Decimal {
+    func outgo(of item: ItemEntity) -> Decimal {
         item.outgo * -1
     }
 }

--- a/Incomes/Sources/Item/Component/DeleteItemButton.swift
+++ b/Incomes/Sources/Item/Component/DeleteItemButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct DeleteItemButton {
-    @Environment(Item.self)
+    @Environment(ItemEntity.self)
     private var item
     @Environment(ItemService.self)
     private var itemService
@@ -44,7 +44,7 @@ extension DeleteItemButton: View {
         ) {
             Button(role: .destructive) {
                 do {
-                    try itemService.delete(items: [item])
+                    try itemService.delete(entities: [item])
                     Haptic.success.impact()
                 } catch {
                     assertionFailure(error.localizedDescription)
@@ -65,6 +65,6 @@ extension DeleteItemButton: View {
 #Preview {
     IncomesPreview { preview in
         DeleteItemButton()
-            .environment(preview.items[.zero])
+            .environment(try! ItemEntity(preview.items[.zero]))
     }
 }

--- a/Incomes/Sources/Item/Component/DuplicateItemButton.swift
+++ b/Incomes/Sources/Item/Component/DuplicateItemButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct DuplicateItemButton {
-    @Environment(Item.self)
+    @Environment(ItemEntity.self)
     private var item
 
     @State private var isPresented = false
@@ -44,6 +44,6 @@ extension DuplicateItemButton: View {
 #Preview {
     IncomesPreview { preview in
         DuplicateItemButton()
-            .environment(preview.items[.zero])
+            .environment(try! ItemEntity(preview.items[.zero]))
     }
 }

--- a/Incomes/Sources/Item/Component/EditItemButton.swift
+++ b/Incomes/Sources/Item/Component/EditItemButton.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct EditItemButton {
-    @Environment(Item.self)
+    @Environment(ItemEntity.self)
     private var item
 
     @State private var isPresented = false
@@ -44,6 +44,6 @@ extension EditItemButton: View {
 #Preview {
     IncomesPreview { preview in
         EditItemButton()
-            .environment(preview.items[.zero])
+            .environment(try! ItemEntity(preview.items[.zero]))
     }
 }

--- a/Incomes/Sources/Item/Component/ItemListSection.swift
+++ b/Incomes/Sources/Item/Component/ItemListSection.swift
@@ -12,15 +12,15 @@ struct ItemListSection {
     @Environment(ItemService.self)
     private var itemService
 
-    @Query private var items: [Item]
+    @BridgeQuery private var items: [ItemEntity]
 
     @State private var isDialogPresented = false
-    @State private var willDeleteItems: [Item] = []
+    @State private var willDeleteItems: [ItemEntity] = []
 
     private let title: LocalizedStringKey?
 
     init(_ descriptor: FetchDescriptor<Item>, title: LocalizedStringKey? = nil) {
-        self._items = Query(descriptor)
+        self._items = .init(Query(descriptor))
         self.title = title
     }
 }
@@ -48,7 +48,7 @@ extension ItemListSection: View {
         ) {
             Button(role: .destructive) {
                 do {
-                    try itemService.delete(items: willDeleteItems)
+                    try itemService.delete(entities: willDeleteItems)
                     Haptic.success.impact()
                 } catch {
                     assertionFailure(error.localizedDescription)

--- a/Incomes/Sources/Item/Component/ItemSection.swift
+++ b/Incomes/Sources/Item/Component/ItemSection.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct ItemSection: View {
-    @Environment(Item.self)
+    @Environment(ItemEntity.self)
     private var item
 
     var body: some View {
@@ -35,7 +35,7 @@ struct ItemSection: View {
             HStack {
                 Text("Category")
                 Spacer()
-                Text(item.category?.displayName ?? .empty)
+                Text(item.category ?? .empty)
                     .foregroundStyle(.secondary)
             }
         } header: {
@@ -48,7 +48,7 @@ struct ItemSection: View {
     IncomesPreview { preview in
         List {
             ItemSection()
-                .environment(preview.items[0])
+                .environment(try! ItemEntity(preview.items[0]))
         }
     }
 }

--- a/Incomes/Sources/Item/Component/ListItem.swift
+++ b/Incomes/Sources/Item/Component/ListItem.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct ListItem: View {
-    @Environment(Item.self)
+    @Environment(ItemEntity.self)
     private var item
     @Environment(ItemService.self)
     private var itemService
@@ -77,7 +77,7 @@ struct ListItem: View {
         ) {
             Button(role: .destructive) {
                 do {
-                    try itemService.delete(items: [item])
+                    try itemService.delete(entities: [item])
                     Haptic.success.impact()
                 } catch {
                     assertionFailure(error.localizedDescription)
@@ -99,7 +99,7 @@ struct ListItem: View {
     IncomesPreview { preview in
         List {
             ListItem()
-                .environment(preview.items[0])
+                .environment(try! ItemEntity(preview.items[0]))
         }
     }
 }

--- a/Incomes/Sources/Item/Component/NarrowListItem.swift
+++ b/Incomes/Sources/Item/Component/NarrowListItem.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct NarrowListItem: View {
-    @Environment(Item.self) private var item
+    @Environment(ItemEntity.self) private var item
 
     var body: some View {
         HStack {
@@ -40,6 +40,6 @@ struct NarrowListItem: View {
 #Preview {
     IncomesPreview { preview in
         NarrowListItem()
-            .environment(preview.items[0])
+            .environment(try! ItemEntity(preview.items[0]))
     }
 }

--- a/Incomes/Sources/Item/Component/ShowItemButton.swift
+++ b/Incomes/Sources/Item/Component/ShowItemButton.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct ShowItemButton {
-    @Environment(Item.self)
+    @Environment(ItemEntity.self)
     private var item
 
     @State private var isPresented = false
@@ -46,6 +46,6 @@ extension ShowItemButton: View {
 #Preview {
     IncomesPreview { preview in
         ShowItemButton()
-            .environment(preview.items[.zero])
+            .environment(try! ItemEntity(preview.items[.zero]))
     }
 }

--- a/Incomes/Sources/Item/Component/TitleListItem.swift
+++ b/Incomes/Sources/Item/Component/TitleListItem.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct TitleListItem: View {
-    @Environment(Item.self) private var item
+    @Environment(ItemEntity.self) private var item
 
     var body: some View {
         HStack {
@@ -31,7 +31,7 @@ struct TitleListItem: View {
     IncomesPreview { preview in
         List {
             TitleListItem()
-                .environment(preview.items[0])
+                .environment(try! ItemEntity(preview.items[0]))
         }
     }
 }

--- a/Incomes/Sources/Item/Component/WideListItem.swift
+++ b/Incomes/Sources/Item/Component/WideListItem.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct WideListItem: View {
-    @Environment(Item.self) private var item
+    @Environment(ItemEntity.self) private var item
 
     var body: some View {
         HStack {
@@ -43,6 +43,6 @@ struct WideListItem: View {
 #Preview(traits: .landscapeRight) {
     IncomesPreview { preview in
         WideListItem()
-            .environment(preview.items[0])
+            .environment(try! ItemEntity(preview.items[0]))
     }
 }

--- a/Incomes/Sources/Item/Model/ItemService.swift
+++ b/Incomes/Sources/Item/Model/ItemService.swift
@@ -152,6 +152,24 @@ final class ItemService {
     }
 }
 
+extension ItemService {
+    func item(entity: ItemEntity) throws -> Item? {
+        guard let id = entity.persistentIdentifier else { return nil }
+        return try item(.items(.idIs(id)))
+    }
+
+    func items(entities: [ItemEntity]) throws -> [Item] {
+        let ids = try entities.compactMap { entity in
+            try Item.ID(base64Encoded: entity.id)
+        }
+        return try items(.items(.idsAre(ids)))
+    }
+
+    func delete(entities: [ItemEntity]) throws {
+        try delete(items: try items(entities: entities))
+    }
+}
+
 private extension ItemService {
     func updateForRepeatingItems(item: Item,
                                  date: Date,

--- a/Incomes/Sources/Item/View/ItemView.swift
+++ b/Incomes/Sources/Item/View/ItemView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import SwiftUtilities
 
 struct ItemView {
-    @Environment(Item.self)
+    @Environment(ItemEntity.self)
     private var item
     @Environment(\.isPresented)
     private var isPresented
@@ -39,7 +39,7 @@ extension ItemView: View {
     IncomesPreview { preview in
         NavigationStack {
             ItemView()
-                .environment(preview.items[0])
+                .environment(try! ItemEntity(preview.items[0]))
         }
     }
 }


### PR DESCRIPTION
## Summary
- adopt `ItemEntity` as a bridgeable type conforming to `ModelBridgeable`
- add helper methods in `ItemService` for working with `ItemEntity`
- replace several `@Query` usages with `@BridgeQuery`
- update related views and previews to receive `ItemEntity`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406c5aa52c8320a6dab0e429232f60