### PR TITLE
Improve project home page

### DIFF
--- a/.github/pages/index.md
+++ b/.github/pages/index.md
@@ -1,22 +1,26 @@
 # Incomes
 
-Incomes is a Cupertino style budget manager for iOS.
+<p align="center">
+  <img src="../../Incomes/Resources/Assets.xcassets/AppIcon.appiconset/AppIcon.png" width="120" alt="Incomes app icon" />
+</p>
 
-[App Store](https://apps.apple.com/app/id1584472982)
+**A modern budget manager for iOS built with SwiftUI.**
 
-## Features
+[![Download on the App Store](https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/appstore-lrg.svg)](https://apps.apple.com/app/id1584472982)
 
-- Quickly record incomes and outgoings with categories
-- Manage recurring items and track balance
-- Search items and filter by tags or categories
-- Optional iCloud sync for subscribers
-- Notification reminders for upcoming payments
-- Customizable currency and push notification settings
-- Built with SwiftUI and SwiftData
+## Key Features
 
-## Building
+- 📊 **Quickly capture** incomes and outgoings with categories
+- ⏰ **Manage recurring items** and keep your balance up to date
+- 🔍 **Search and filter** by tags or categories
+- ☁️ **iCloud sync** for subscribers
+- 🔔 **Custom notifications** for upcoming payments
+- ⚙️ **Built with SwiftUI and SwiftData**
 
-Open `Incomes.xcodeproj` with Xcode 15 or later and run the **Incomes** scheme on an iOS 17.0 or later device.
+## Getting Started
+
+Clone the repository and open `Incomes.xcodeproj` with Xcode 15 or later. Run the **Incomes** scheme on an iOS 17.0 or later device.
 
 The app loads `.config.json` from GitHub at launch to determine if an update is required.
 
+[Privacy Policy](privacy.html)


### PR DESCRIPTION
## Summary
- redesign `index.md` for GitHub Pages with a centered app icon
- add an App Store badge and icons for feature list
- include quick link to privacy policy

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68450aa64e64832095c054237920de92