### PR TITLE
Implement StaticPerformIntent and update intents

### DIFF
--- a/Incomes/Sources/AppIntent/Intent/CreateItemIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/CreateItemIntent.swift
@@ -8,7 +8,7 @@
 
 import AppIntents
 
-struct CreateItemIntent: AppIntent, @unchecked Sendable {
+struct CreateItemIntent: StaticPerformIntent, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Create Item", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -26,13 +26,24 @@ struct CreateItemIntent: AppIntent, @unchecked Sendable {
 
     @Dependency private var itemService: ItemService
 
-    static func perform(date: Date,
-                        content: String,
-                        income: Double,
-                        outgo: Double,
-                        category: String,
-                        repeatCount: Int,
-                        itemService: ItemService) throws -> Item {
+    struct Arguments {
+        let date: Date
+        let content: String
+        let income: Double
+        let outgo: Double
+        let category: String
+        let repeatCount: Int
+        let itemService: ItemService
+    }
+
+    static func perform(_ arguments: Arguments) throws -> Item {
+        let date = arguments.date
+        let content = arguments.content
+        let income = arguments.income
+        let outgo = arguments.outgo
+        let category = arguments.category
+        let repeatCount = arguments.repeatCount
+        let itemService = arguments.itemService
         guard content.isNotEmpty else {
             throw DebugError.default
         }
@@ -47,18 +58,20 @@ struct CreateItemIntent: AppIntent, @unchecked Sendable {
     }
 
     func perform() throws -> some ReturnsValue<ItemEntity> {
-        let item = try Self.perform(date: date,
-                                    content: content,
-                                    income: income,
-                                    outgo: outgo,
-                                    category: category,
-                                    repeatCount: repeatCount,
-                                    itemService: itemService)
+        let item = try Self.perform(
+            .init(date: date,
+                  content: content,
+                  income: income,
+                  outgo: outgo,
+                  category: category,
+                  repeatCount: repeatCount,
+                  itemService: itemService)
+        )
         return .result(value: try .init(item))
     }
 }
 
-struct CreateAndShowItemIntent: AppIntent, @unchecked Sendable {
+struct CreateAndShowItemIntent: StaticPerformIntent, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Create and Show Item", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -76,13 +89,24 @@ struct CreateAndShowItemIntent: AppIntent, @unchecked Sendable {
 
     @Dependency private var itemService: ItemService
 
-    static func perform(date: Date,
-                        content: String,
-                        income: Double,
-                        outgo: Double,
-                        category: String,
-                        repeatCount: Int,
-                        itemService: ItemService) throws -> Item {
+    struct Arguments {
+        let date: Date
+        let content: String
+        let income: Double
+        let outgo: Double
+        let category: String
+        let repeatCount: Int
+        let itemService: ItemService
+    }
+
+    static func perform(_ arguments: Arguments) throws -> Item {
+        let date = arguments.date
+        let content = arguments.content
+        let income = arguments.income
+        let outgo = arguments.outgo
+        let category = arguments.category
+        let repeatCount = arguments.repeatCount
+        let itemService = arguments.itemService
         guard content.isNotEmpty else {
             throw DebugError.default
         }
@@ -97,13 +121,15 @@ struct CreateAndShowItemIntent: AppIntent, @unchecked Sendable {
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        let item = try Self.perform(date: date,
-                                    content: content,
-                                    income: income,
-                                    outgo: outgo,
-                                    category: category,
-                                    repeatCount: repeatCount,
-                                    itemService: itemService)
+        let item = try Self.perform(
+            .init(date: date,
+                  content: content,
+                  income: income,
+                  outgo: outgo,
+                  category: category,
+                  repeatCount: repeatCount,
+                  itemService: itemService)
+        )
         return .result(dialog: .init(stringLiteral: item.content)) {
             IntentItemSection()
                 .environment(item)

--- a/Incomes/Sources/AppIntent/Intent/GetNextItemIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/GetNextItemIntent.swift
@@ -9,7 +9,7 @@
 import AppIntents
 import SwiftUI
 
-struct GetNextItemIntent: AppIntent, @unchecked Sendable {
+struct GetNextItemIntent: StaticPerformIntent, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Get Next Item", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -17,13 +17,17 @@ struct GetNextItemIntent: AppIntent, @unchecked Sendable {
 
     @Dependency private var itemService: ItemService
 
-    static func perform(date: Date,
-                        itemService: ItemService) throws -> Item? {
-        try itemService.item(.items(.dateIsAfter(date), order: .forward))
+    struct Arguments {
+        let date: Date
+        let itemService: ItemService
+    }
+
+    static func perform(_ arguments: Arguments) throws -> Item? {
+        try arguments.itemService.item(.items(.dateIsAfter(arguments.date), order: .forward))
     }
 
     func perform() throws -> some ReturnsValue<ItemEntity?> {
-        guard let item = try Self.perform(date: date, itemService: itemService) else {
+        guard let item = try Self.perform(.init(date: date, itemService: itemService)) else {
             return .result(value: nil)
         }
         return .result(value: try .init(item))
@@ -39,7 +43,7 @@ struct GetNextItemDateIntent: AppIntent, @unchecked Sendable {
     @Dependency private var itemService: ItemService
 
     func perform() throws -> some ReturnsValue<Date?> {
-        guard let item = try GetNextItemIntent.perform(date: date, itemService: itemService) else {
+        guard let item = try GetNextItemIntent.perform(.init(date: date, itemService: itemService)) else {
             return .result(value: nil)
         }
         return .result(value: item.localDate)
@@ -55,7 +59,7 @@ struct GetNextItemContentIntent: AppIntent, @unchecked Sendable {
     @Dependency private var itemService: ItemService
 
     func perform() throws -> some ReturnsValue<String?> {
-        guard let item = try GetNextItemIntent.perform(date: date, itemService: itemService) else {
+        guard let item = try GetNextItemIntent.perform(.init(date: date, itemService: itemService)) else {
             return .result(value: nil)
         }
         return .result(value: item.content)
@@ -71,7 +75,7 @@ struct GetNextItemProfitIntent: AppIntent, @unchecked Sendable {
     @Dependency private var itemService: ItemService
 
     func perform() throws -> some ReturnsValue<IntentCurrencyAmount?> {
-        guard let item = try GetNextItemIntent.perform(date: date, itemService: itemService) else {
+        guard let item = try GetNextItemIntent.perform(.init(date: date, itemService: itemService)) else {
             return .result(value: nil)
         }
         let currencyCode = AppStorage(.currencyCode).wrappedValue
@@ -88,7 +92,7 @@ struct ShowNextItemIntent: AppIntent, @unchecked Sendable {
     @Dependency private var itemService: ItemService
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let item = try GetNextItemIntent.perform(date: date, itemService: itemService) else {
+        guard let item = try GetNextItemIntent.perform(.init(date: date, itemService: itemService)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {
@@ -105,7 +109,7 @@ struct ShowUpcomingItemIntent: AppIntent, @unchecked Sendable {
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let item = try GetNextItemIntent.perform(date: date, itemService: itemService) else {
+        guard let item = try GetNextItemIntent.perform(.init(date: date, itemService: itemService)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/AppIntent/Intent/GetPreviousItemsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/GetPreviousItemsIntent.swift
@@ -8,7 +8,7 @@
 
 import AppIntents
 
-struct GetPreviousItemsIntent: AppIntent, @unchecked Sendable {
+struct GetPreviousItemsIntent: StaticPerformIntent, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Get Previous Items", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -16,16 +16,20 @@ struct GetPreviousItemsIntent: AppIntent, @unchecked Sendable {
 
     @Dependency private var itemService: ItemService
 
-    static func perform(date: Date,
-                        itemService: ItemService) throws -> [Item]? {
-        guard let item = try itemService.item(.items(.dateIsBefore(date))) else {
+    struct Arguments {
+        let date: Date
+        let itemService: ItemService
+    }
+
+    static func perform(_ arguments: Arguments) throws -> [Item]? {
+        guard let item = try arguments.itemService.item(.items(.dateIsBefore(arguments.date))) else {
             return nil
         }
-        return try itemService.items(.items(.dateIsSameDayAs(item.localDate)))
+        return try arguments.itemService.items(.items(.dateIsSameDayAs(item.localDate)))
     }
 
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
-        guard let items = try Self.perform(date: date, itemService: itemService) else {
+        guard let items = try Self.perform(.init(date: date, itemService: itemService)) else {
             return .result(value: .empty)
         }
         return .result(value: try items.map { try .init($0) })
@@ -41,7 +45,7 @@ struct ShowPreviousItemsIntent: AppIntent, @unchecked Sendable {
     @Dependency private var itemService: ItemService
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let items = try GetPreviousItemsIntent.perform(date: date, itemService: itemService),
+        guard let items = try GetPreviousItemsIntent.perform(.init(date: date, itemService: itemService)),
               items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
@@ -58,7 +62,7 @@ struct ShowRecentItemsIntent: AppIntent, @unchecked Sendable {
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try GetPreviousItemsIntent.perform(date: date, itemService: itemService),
+        guard let items = try GetPreviousItemsIntent.perform(.init(date: date, itemService: itemService)),
               items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }

--- a/Incomes/Sources/AppIntent/Intent/OpenIncomesIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/OpenIncomesIntent.swift
@@ -8,15 +8,17 @@
 
 import AppIntents
 
-struct OpenIncomesIntent: AppIntent {
+struct OpenIncomesIntent: StaticPerformIntent {
     static let title: LocalizedStringResource = .init("Open Incomes", table: "AppIntents")
     static let openAppWhenRun = true
 
-    static func perform() -> some IntentResult {
+    typealias Arguments = Void
+
+    static func perform(_ arguments: Arguments = ()) throws -> any IntentResult {
         .result()
     }
 
     func perform() throws -> some IntentResult {
-        Self.perform()
+        try Self.perform()
     }
 }

--- a/Incomes/Sources/AppIntent/Model/StaticPerformIntent.swift
+++ b/Incomes/Sources/AppIntent/Model/StaticPerformIntent.swift
@@ -1,0 +1,14 @@
+//
+//  StaticPerformIntent.swift
+//  Incomes
+//
+//  Created by Codex on 2025/06/09.
+//
+
+import AppIntents
+
+protocol StaticPerformIntent: AppIntent {
+    associatedtype Arguments
+
+    static func perform(_ arguments: Arguments) throws -> any IntentResult
+}


### PR DESCRIPTION
## Summary
- add `StaticPerformIntent` protocol for static `perform` with arguments
- update all AppIntents to conform to `StaticPerformIntent`
- replace static calls with new `Arguments` structs

## Testing
- `pre-commit run --files Incomes/Sources/AppIntent/Model/StaticPerformIntent.swift Incomes/Sources/AppIntent/Intent/OpenIncomesIntent.swift Incomes/Sources/AppIntent/Intent/CreateItemIntent.swift Incomes/Sources/AppIntent/Intent/GetNextItemIntent.swift Incomes/Sources/AppIntent/Intent/GetNextItemsIntent.swift Incomes/Sources/AppIntent/Intent/GetPreviousItemIntent.swift Incomes/Sources/AppIntent/Intent/GetPreviousItemsIntent.swift Incomes/Sources/AppIntent/Intent/GetItemsIntent.swift` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847401bd3788320a3a145cdb3493d80