### PR TITLE
Ensure all AppIntents conform to IntentPerformer

### DIFF
--- a/Incomes/Sources/AppIntent/Intent/Get/GetItemsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Get/GetItemsIntent.swift
@@ -8,7 +8,7 @@
 
 import AppIntents
 
-struct GetItemsIntent: AppIntent, @unchecked Sendable {
+struct GetItemsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Get Items", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -16,13 +16,15 @@ struct GetItemsIntent: AppIntent, @unchecked Sendable {
 
     @Dependency private var itemService: ItemService
 
-    static func perform(date: Date,
-                        itemService: ItemService) throws -> [Item] {
-        try itemService.items(.items(.dateIsSameMonthAs(date)))
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]
+
+    static func perform(_ input: Input) throws -> Output {
+        try input.itemService.items(.items(.dateIsSameMonthAs(input.date)))
     }
 
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
-        let items = try Self.perform(date: date, itemService: itemService)
+        let items = try Self.perform((date: date, itemService: itemService))
         return .result(value: try items.map { try .init($0) })
     }
 }

--- a/Incomes/Sources/AppIntent/Intent/Open/OpenIncomesIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Open/OpenIncomesIntent.swift
@@ -8,11 +8,17 @@
 
 import AppIntents
 
-struct OpenIncomesIntent: AppIntent {
+struct OpenIncomesIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Open Incomes", table: "AppIntents")
     static let openAppWhenRun = true
 
+    typealias Input = Void
+    typealias Output = Void
+
+    static func perform(_ input: Input) throws -> Output {}
+
     func perform() throws -> some IntentResult {
-        .result()
+        try Self.perform(())
+        return .result()
     }
 }

--- a/Incomes/Sources/AppIntent/Intent/Show/ShowChartsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Show/ShowChartsIntent.swift
@@ -9,7 +9,7 @@
 import AppIntents
 import SwiftData
 
-struct ShowChartsIntent: AppIntent, @unchecked Sendable {
+struct ShowChartsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Show Charts", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -18,14 +18,16 @@ struct ShowChartsIntent: AppIntent, @unchecked Sendable {
     @Dependency private var itemService: ItemService
     @Dependency private var modelContainer: ModelContainer
 
-    static func perform(date: Date,
-                        itemService: ItemService) throws -> [Item]? {
-        let items = try itemService.items(.items(.dateIsSameMonthAs(date)))
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]?
+
+    static func perform(_ input: Input) throws -> Output {
+        let items = try input.itemService.items(.items(.dateIsSameMonthAs(input.date)))
         return items.isEmpty ? nil : items
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let items = try Self.perform(date: date, itemService: itemService) else {
+        guard let items = try Self.perform((date: date, itemService: itemService)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/AppIntent/Intent/Show/ShowItemsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Show/ShowItemsIntent.swift
@@ -8,7 +8,7 @@
 
 import AppIntents
 
-struct ShowItemsIntent: AppIntent, @unchecked Sendable {
+struct ShowItemsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Show Items", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -16,14 +16,16 @@ struct ShowItemsIntent: AppIntent, @unchecked Sendable {
 
     @Dependency private var itemService: ItemService
 
-    static func perform(date: Date,
-                        itemService: ItemService) throws -> [Item]? {
-        let items = try itemService.items(.items(.dateIsSameMonthAs(date)))
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]?
+
+    static func perform(_ input: Input) throws -> Output {
+        let items = try input.itemService.items(.items(.dateIsSameMonthAs(input.date)))
         return items.isEmpty ? nil : items
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let items = try Self.perform(date: date, itemService: itemService) else {
+        guard let items = try Self.perform((date: date, itemService: itemService)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/AppIntent/Intent/Show/ShowNextItemsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Show/ShowNextItemsIntent.swift
@@ -8,7 +8,7 @@
 
 import AppIntents
 
-struct ShowNextItemsIntent: AppIntent, @unchecked Sendable {
+struct ShowNextItemsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Show Next Items", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -16,8 +16,15 @@ struct ShowNextItemsIntent: AppIntent, @unchecked Sendable {
 
     @Dependency private var itemService: ItemService
 
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]?
+
+    static func perform(_ input: Input) throws -> Output {
+        try GetNextItemsIntent.perform(input)
+    }
+
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let items = try GetNextItemsIntent.perform(date: date, itemService: itemService),
+        guard let items = try Self.perform((date: date, itemService: itemService)),
               items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }

--- a/Incomes/Sources/AppIntent/Intent/Show/ShowPreviousItemsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Show/ShowPreviousItemsIntent.swift
@@ -8,7 +8,7 @@
 
 import AppIntents
 
-struct ShowPreviousItemsIntent: AppIntent, @unchecked Sendable {
+struct ShowPreviousItemsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Show Previous Items", table: "AppIntents")
 
     @Parameter(title: "Date", kind: .date)
@@ -16,8 +16,15 @@ struct ShowPreviousItemsIntent: AppIntent, @unchecked Sendable {
 
     @Dependency private var itemService: ItemService
 
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]?
+
+    static func perform(_ input: Input) throws -> Output {
+        try GetPreviousItemsIntent.perform(input)
+    }
+
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let items = try GetPreviousItemsIntent.perform(date: date, itemService: itemService),
+        guard let items = try Self.perform((date: date, itemService: itemService)),
               items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }

--- a/Incomes/Sources/AppIntent/Intent/Show/ShowRecentItemsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Show/ShowRecentItemsIntent.swift
@@ -8,14 +8,21 @@
 
 import AppIntents
 
-struct ShowRecentItemsIntent: AppIntent, @unchecked Sendable {
+struct ShowRecentItemsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Show Recent Items", table: "AppIntents")
 
     @Dependency private var itemService: ItemService
 
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]?
+
+    static func perform(_ input: Input) throws -> Output {
+        try GetPreviousItemsIntent.perform(input)
+    }
+
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try GetPreviousItemsIntent.perform(date: date, itemService: itemService),
+        guard let items = try Self.perform((date: date, itemService: itemService)),
               items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }

--- a/Incomes/Sources/AppIntent/Intent/Show/ShowThisMonthChartsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Show/ShowThisMonthChartsIntent.swift
@@ -9,15 +9,22 @@
 import AppIntents
 import SwiftData
 
-struct ShowThisMonthChartsIntent: AppIntent, @unchecked Sendable {
+struct ShowThisMonthChartsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Show This Month's Charts", table: "AppIntents")
 
     @Dependency private var itemService: ItemService
     @Dependency private var modelContainer: ModelContainer
 
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]?
+
+    static func perform(_ input: Input) throws -> Output {
+        try ShowChartsIntent.perform(input)
+    }
+
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try ShowChartsIntent.perform(date: date, itemService: itemService) else {
+        guard let items = try Self.perform((date: date, itemService: itemService)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/AppIntent/Intent/Show/ShowThisMonthItemsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Show/ShowThisMonthItemsIntent.swift
@@ -8,14 +8,21 @@
 
 import AppIntents
 
-struct ShowThisMonthItemsIntent: AppIntent, @unchecked Sendable {
+struct ShowThisMonthItemsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Show This Month's Items", table: "AppIntents")
 
     @Dependency private var itemService: ItemService
 
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]?
+
+    static func perform(_ input: Input) throws -> Output {
+        try ShowItemsIntent.perform(input)
+    }
+
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try ShowItemsIntent.perform(date: date, itemService: itemService) else {
+        guard let items = try Self.perform((date: date, itemService: itemService)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/AppIntent/Intent/Show/ShowUpcomingItemsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Show/ShowUpcomingItemsIntent.swift
@@ -8,14 +8,21 @@
 
 import AppIntents
 
-struct ShowUpcomingItemsIntent: AppIntent, @unchecked Sendable {
+struct ShowUpcomingItemsIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     static let title: LocalizedStringResource = .init("Show Upcoming Items", table: "AppIntents")
 
     @Dependency private var itemService: ItemService
 
+    typealias Input = (date: Date, itemService: ItemService)
+    typealias Output = [Item]?
+
+    static func perform(_ input: Input) throws -> Output {
+        try GetNextItemsIntent.perform(input)
+    }
+
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try GetNextItemsIntent.perform(date: date, itemService: itemService),
+        guard let items = try Self.perform((date: date, itemService: itemService)),
               items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }


### PR DESCRIPTION
## Summary
- make all AppIntent types adopt `IntentPerformer`
- expose Input/Output typealiases and static `perform` methods for each intent

## Testing
- `swiftlint` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68484280c1e8832097f20559aa6329b2