### PR TITLE
Move item creation logic to CreateItemIntent

### DIFF
--- a/Incomes/Sources/AppIntent/Intent/Create/CreateAndShowItemIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Create/CreateAndShowItemIntent.swift
@@ -49,6 +49,7 @@ struct CreateAndShowItemIntent: AppIntent, IntentPerformer, @unchecked Sendable 
         )
     }
 
+    @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let item = try Self.perform((context: modelContainer.mainContext,
                                      date: date,

--- a/Incomes/Sources/AppIntent/Intent/Create/CreateItemIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Create/CreateItemIntent.swift
@@ -82,6 +82,7 @@ struct CreateItemIntent: AppIntent, IntentPerformer, @unchecked Sendable {
         return entity
     }
 
+    @MainActor
     func perform() throws -> some ReturnsValue<ItemEntity> {
         guard content.isNotEmpty else {
             throw $content.needsValueError()

--- a/Incomes/Sources/AppIntent/Intent/Create/CreateItemIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Create/CreateItemIntent.swift
@@ -7,6 +7,7 @@
 //
 
 import AppIntents
+import SwiftData
 import SwiftUI
 import SwiftUtilities
 
@@ -26,25 +27,59 @@ struct CreateItemIntent: AppIntent, IntentPerformer, @unchecked Sendable {
     @Parameter(title: "Repeat", default: 1, inclusiveRange: (1, 60))
     private var repeatCount: Int
 
-    @Dependency private var itemService: ItemService
+    @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (date: Date, content: String, income: Decimal, outgo: Decimal, category: String, repeatCount: Int, itemService: ItemService)
+    typealias Input = (context: ModelContext, date: Date, content: String, income: Decimal, outgo: Decimal, category: String, repeatCount: Int)
     typealias Output = ItemEntity
 
     static func perform(_ input: Input) throws -> Output {
-        let (date, content, income, outgo, category, repeatCount, itemService) = input
-        let model = try itemService.create(
+        let (context, date, content, income, outgo, category, repeatCount) = input
+        var items = [Item]()
+
+        let repeatID = UUID()
+
+        let model = try Item.create(
+            context: context,
             date: date,
             content: content,
             income: income,
             outgo: outgo,
             category: category,
-            repeatCount: repeatCount
+            repeatID: repeatID
         )
-        guard let item = ItemEntity(model) else {
+        items.append(model)
+
+        for index in 0..<repeatCount {
+            guard index > .zero else {
+                continue
+            }
+            guard let repeatingDate = Calendar.current.date(byAdding: .month,
+                                                            value: index,
+                                                            to: date) else {
+                assertionFailure()
+                continue
+            }
+            let item = try Item.create(
+                context: context,
+                date: repeatingDate,
+                content: content,
+                income: income,
+                outgo: outgo,
+                category: category,
+                repeatID: repeatID
+            )
+            items.append(item)
+        }
+
+        items.forEach(context.insert)
+
+        let calculator = BalanceCalculator(context: context)
+        try calculator.calculate(for: items)
+
+        guard let entity = ItemEntity(model) else {
             throw DebugError.default
         }
-        return item
+        return entity
     }
 
     func perform() throws -> some ReturnsValue<ItemEntity> {
@@ -62,13 +97,13 @@ struct CreateItemIntent: AppIntent, IntentPerformer, @unchecked Sendable {
 
         let item = try Self.perform(
             (
+                context: modelContainer.mainContext,
                 date: date,
                 content: content,
                 income: income.amount,
                 outgo: outgo.amount,
                 category: category,
-                repeatCount: repeatCount,
-                itemService: itemService
+                repeatCount: repeatCount
             )
         )
         return .result(value: item)

--- a/Incomes/Sources/Item/Model/ItemService.swift
+++ b/Incomes/Sources/Item/Model/ItemService.swift
@@ -40,58 +40,6 @@ final class ItemService {
         try context.fetchCount(descriptor)
     }
 
-    // MARK: - Create
-
-    func create(date: Date,
-                content: String,
-                income: Decimal,
-                outgo: Decimal,
-                category: String,
-                repeatCount: Int = 1) throws -> Item {
-        var items = [Item]()
-
-        let repeatID = UUID()
-
-        let item = try Item.create(
-            context: context,
-            date: date,
-            content: content,
-            income: income,
-            outgo: outgo,
-            category: category,
-            repeatID: repeatID
-        )
-        items.append(item)
-
-        for index in 0..<repeatCount {
-            guard index > .zero else {
-                continue
-            }
-            guard let repeatingDate = Calendar.current.date(byAdding: .month,
-                                                            value: index,
-                                                            to: date) else {
-                assertionFailure()
-                continue
-            }
-            let item = try Item.create(
-                context: context,
-                date: repeatingDate,
-                content: content,
-                income: income,
-                outgo: outgo,
-                category: category,
-                repeatID: repeatID
-            )
-            items.append(item)
-        }
-
-        items.forEach(context.insert)
-
-        try calculator.calculate(for: items)
-
-        return item
-    }
-
     // MARK: - Update
 
     func update(item: Item,

--- a/Incomes/Sources/Item/View/ItemFormView.swift
+++ b/Incomes/Sources/Item/View/ItemFormView.swift
@@ -33,6 +33,8 @@ struct ItemFormView {
     private var item: ItemEntity?
     @Environment(ItemService.self)
     private var itemService
+    @Environment(\.modelContext)
+    private var context
 
     @AppStorage(.isDebugOn)
     private var isDebugOn
@@ -300,13 +302,13 @@ private extension ItemFormView {
         do {
             _ = try CreateItemIntent.perform(
                 (
+                    context: context,
                     date: date,
                     content: content,
                     income: income.decimalValue,
                     outgo: outgo.decimalValue,
                     category: category,
-                    repeatCount: repeatSelection,
-                    itemService: itemService
+                    repeatCount: repeatSelection
                 )
             )
             Haptic.success.impact()

--- a/IncomesTests/Default/CreateItemIntentTests.swift
+++ b/IncomesTests/Default/CreateItemIntentTests.swift
@@ -1,0 +1,47 @@
+@testable import Incomes
+import SwiftData
+import Testing
+
+struct CreateItemIntentTests {
+    let context: ModelContext
+
+    init() {
+        context = testContext
+    }
+
+    @Test func perform() throws {
+        _ = try CreateItemIntent.perform(
+            (
+                context: context,
+                date: isoDate("2000-01-01T12:00:00Z"),
+                content: "content",
+                income: 200,
+                outgo: 100,
+                category: "category",
+                repeatCount: 1
+            )
+        )
+        let result = fetchItems(context).first!
+        #expect(result.utcDate == isoDate("2000-01-01T00:00:00Z"))
+        #expect(result.content == "content")
+        #expect(result.balance == 100)
+    }
+
+    @Test func performRepeat() throws {
+        _ = try CreateItemIntent.perform(
+            (
+                context: context,
+                date: isoDate("2000-01-01T12:00:00Z"),
+                content: "content",
+                income: 200,
+                outgo: 100,
+                category: "category",
+                repeatCount: 3
+            )
+        )
+        let items = fetchItems(context)
+        #expect(items.count == 3)
+        #expect(Set(items.map(\.repeatID)).count == 1)
+    }
+}
+

--- a/IncomesTests/Default/ItemServiceXCTests.swift
+++ b/IncomesTests/Default/ItemServiceXCTests.swift
@@ -7,58 +7,10 @@
 //
 
 @testable import Incomes
+import SwiftData
 import XCTest
 
 final class ItemServiceXCTests: XCTestCase {
-    // MARK: - Create
-
-    func testCreate() {
-        XCTContext.runActivity(named: "Result is as expected") { _ in
-            let context = testContext
-            let service = ItemService(context: context)
-
-            _ = try! service.create(date: isoDate("2000-01-01T12:00:00Z"),
-                                    content: "content",
-                                    income: 200,
-                                    outgo: 100,
-                                    category: "category")
-            let result = fetchItems(context).first!
-
-            XCTAssertEqual(result.utcDate, isoDate("2000-01-01T00:00:00Z"))
-            XCTAssertEqual(result.content, "content")
-            XCTAssertEqual(result.income, 200)
-            XCTAssertEqual(result.outgo, 100)
-            XCTAssertEqual(result.balance, 100)
-        }
-
-        XCTContext.runActivity(named: "Result is as expected when repeatCount 3") { _ in
-            let context = testContext
-            let service = ItemService(context: context)
-
-            _ = try! service.create(date: isoDate("2000-01-01T12:00:00Z"),
-                                    content: "content",
-                                    income: 200,
-                                    outgo: 100,
-                                    category: "category",
-                                    repeatCount: 3)
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
-
-            XCTAssertEqual(first.utcDate, isoDate("2000-03-01T00:00:00Z"))
-            XCTAssertEqual(first.content, "content")
-            XCTAssertEqual(first.income, 200)
-            XCTAssertEqual(first.outgo, 100)
-            XCTAssertEqual(first.balance, 300)
-
-            XCTAssertEqual(last.utcDate, isoDate("2000-01-01T00:00:00Z"))
-            XCTAssertEqual(last.content, "content")
-            XCTAssertEqual(last.income, 200)
-            XCTAssertEqual(last.outgo, 100)
-            XCTAssertEqual(last.balance, 100)
-
-            XCTAssertEqual(first.repeatID, last.repeatID)
-        }
-    }
 
     // MARK: - Update
 
@@ -66,11 +18,17 @@ final class ItemServiceXCTests: XCTestCase {
         XCTContext.runActivity(named: "Result is as expected") { _ in
             let context = testContext
             let service = ItemService(context: context)
-            _ = try! service.create(date: isoDate("2000-01-01T12:00:00Z"),
-                                    content: "content",
-                                    income: 200,
-                                    outgo: 100,
-                                    category: "category")
+            _ = try! CreateItemIntent.perform(
+                (
+                    context: context,
+                    date: isoDate("2000-01-01T12:00:00Z"),
+                    content: "content",
+                    income: 200,
+                    outgo: 100,
+                    category: "category",
+                    repeatCount: 1
+                )
+            )
 
             try! service.update(item: fetchItems(context).first!,
                                 date: isoDate("2001-01-02T12:00:00Z"),
@@ -90,12 +48,17 @@ final class ItemServiceXCTests: XCTestCase {
         XCTContext.runActivity(named: "Result is as expected when repeatCount 3") { _ in
             let context = testContext
             let service = ItemService(context: context)
-            _ = try! service.create(date: isoDate("2000-01-01T12:00:00Z"),
-                                    content: "content",
-                                    income: 200,
-                                    outgo: 100,
-                                    category: "category",
-                                    repeatCount: 3)
+            _ = try! CreateItemIntent.perform(
+                (
+                    context: context,
+                    date: isoDate("2000-01-01T12:00:00Z"),
+                    content: "content",
+                    income: 200,
+                    outgo: 100,
+                    category: "category",
+                    repeatCount: 3
+                )
+            )
 
             try! service.update(item: fetchItems(context)[1],
                                 date: isoDate("2000-02-02T12:00:00Z"),
@@ -135,11 +98,17 @@ final class ItemServiceXCTests: XCTestCase {
         XCTContext.runActivity(named: "Result is as expected") { _ in
             let context = testContext
             let service = ItemService(context: context)
-            _ = try! service.create(date: isoDate("2000-01-01T12:00:00Z"),
-                                    content: "content",
-                                    income: 200,
-                                    outgo: 100,
-                                    category: "category")
+            _ = try! CreateItemIntent.perform(
+                (
+                    context: context,
+                    date: isoDate("2000-01-01T12:00:00Z"),
+                    content: "content",
+                    income: 200,
+                    outgo: 100,
+                    category: "category",
+                    repeatCount: 1
+                )
+            )
 
             try! service.updateForFutureItems(item: fetchItems(context).first!,
                                               date: isoDate("2001-01-02T12:00:00Z"),
@@ -159,12 +128,17 @@ final class ItemServiceXCTests: XCTestCase {
         XCTContext.runActivity(named: "Result is as expected when repeatCount 3") { _ in
             let context = testContext
             let service = ItemService(context: context)
-            _ = try! service.create(date: isoDate("2000-01-01T12:00:00Z"),
-                                    content: "content",
-                                    income: 200,
-                                    outgo: 100,
-                                    category: "category",
-                                    repeatCount: 3)
+            _ = try! CreateItemIntent.perform(
+                (
+                    context: context,
+                    date: isoDate("2000-01-01T12:00:00Z"),
+                    content: "content",
+                    income: 200,
+                    outgo: 100,
+                    category: "category",
+                    repeatCount: 3
+                )
+            )
 
             try! service.updateForFutureItems(item: fetchItems(context)[1],
                                               date: isoDate("2000-02-02T12:00:00Z"),
@@ -204,11 +178,17 @@ final class ItemServiceXCTests: XCTestCase {
         XCTContext.runActivity(named: "Result is as expected") { _ in
             let context = testContext
             let service = ItemService(context: context)
-            _ = try! service.create(date: isoDate("2000-01-01T12:00:00Z"),
-                                    content: "content",
-                                    income: 200,
-                                    outgo: 100,
-                                    category: "category")
+            _ = try! CreateItemIntent.perform(
+                (
+                    context: context,
+                    date: isoDate("2000-01-01T12:00:00Z"),
+                    content: "content",
+                    income: 200,
+                    outgo: 100,
+                    category: "category",
+                    repeatCount: 1
+                )
+            )
 
             try! service.updateForAllItems(item: fetchItems(context).first!,
                                            date: isoDate("2001-01-02T12:00:00Z"),
@@ -228,12 +208,17 @@ final class ItemServiceXCTests: XCTestCase {
         XCTContext.runActivity(named: "Result is as expected when repeatCount 3") { _ in
             let context = testContext
             let service = ItemService(context: context)
-            _ = try! service.create(date: isoDate("2000-01-01T12:00:00Z"),
-                                    content: "content",
-                                    income: 200,
-                                    outgo: 100,
-                                    category: "category",
-                                    repeatCount: 3)
+            _ = try! CreateItemIntent.perform(
+                (
+                    context: context,
+                    date: isoDate("2000-01-01T12:00:00Z"),
+                    content: "content",
+                    income: 200,
+                    outgo: 100,
+                    category: "category",
+                    repeatCount: 3
+                )
+            )
 
             try! service.updateForAllItems(item: fetchItems(context)[1],
                                            date: isoDate("2000-02-02T12:00:00Z"),

--- a/IncomesTests/TimeZone/ItemPredicateTest.swift
+++ b/IncomesTests/TimeZone/ItemPredicateTest.swift
@@ -27,8 +27,8 @@ struct ItemPredicateTest {
     func returnsAllItemsWithAllPredicate(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(date: shiftedDate("2024-01-01T00:00:00Z"), content: "One", income: 100, outgo: 0, category: "A")
-        _ = try service.create(date: shiftedDate("2024-02-01T00:00:00Z"), content: "Two", income: 200, outgo: 0, category: "B")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-01-01T00:00:00Z"), content: "One", income: 100, outgo: 0, category: "A", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-02-01T00:00:00Z"), content: "Two", income: 200, outgo: 0, category: "B", repeatCount: 1))
 
         let predicate = ItemPredicate.all
         let items = try service.items(.items(predicate))
@@ -45,7 +45,7 @@ struct ItemPredicateTest {
     func returnsNoItemsWithNonePredicate(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(date: shiftedDate("2024-01-01T00:00:00Z"), content: "One", income: 100, outgo: 0, category: "A")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-01-01T00:00:00Z"), content: "One", income: 100, outgo: 0, category: "A", repeatCount: 1))
 
         let predicate = ItemPredicate.none
         let items = try service.items(.items(predicate))
@@ -60,7 +60,7 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let date = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try service.create(date: date, content: "Content", income: 0, outgo: 0, category: "Category")
+        _ = try CreateItemIntent.perform((context: context, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
         let tag = try Tag.create(context: context, name: "2024", type: .year)
         let predicate = ItemPredicate.tagIs(tag)
@@ -78,7 +78,7 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let date = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try service.create(date: date, content: "Content", income: 0, outgo: 0, category: "Category")
+        _ = try CreateItemIntent.perform((context: context, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
         let tag = try Tag.create(context: context, name: "202401", type: .yearMonth)
         let predicate = ItemPredicate.tagIs(tag)
@@ -96,7 +96,7 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let date = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try service.create(date: date, content: "Content", income: 0, outgo: 0, category: "Category")
+        _ = try CreateItemIntent.perform((context: context, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
         let tag = try Tag.create(context: context, name: "Content", type: .content)
         let predicate = ItemPredicate.tagAndYear(tag: tag, yearString: "2024")
@@ -116,7 +116,7 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try service.create(date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsBefore(cutoff)
         let items = try service.items(.items(predicate))
@@ -131,8 +131,8 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try service.create(date: shiftedDate("2024-04-30T23:59:59Z"), content: "April", income: 1, outgo: 0, category: "Test")
-        _ = try service.create(date: cutoff, content: "May", income: 1, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-04-30T23:59:59Z"), content: "April", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: cutoff, content: "May", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsBefore(cutoff)
         let items = try service.items(.items(predicate))
@@ -148,9 +148,9 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try service.create(date: shiftedDate("2024-04-01T00:00:00Z"), content: "EarlyApril", income: 0, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-04-15T00:00:00Z"), content: "MidApril", income: 0, outgo: 0, category: "Test")
-        _ = try service.create(date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-04-01T00:00:00Z"), content: "EarlyApril", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-04-15T00:00:00Z"), content: "MidApril", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsBefore(cutoff)
         let items = try service.items(.items(predicate))
@@ -167,8 +167,8 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try service.create(date: shiftedDate("2024-05-01T00:00:01Z"), content: "After", income: 1, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-04-30T23:59:59Z"), content: "Before", income: 1, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-05-01T00:00:01Z"), content: "After", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-04-30T23:59:59Z"), content: "Before", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsAfter(cutoff)
         let items = try service.items(.items(predicate))
@@ -184,9 +184,9 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try service.create(date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-05-02T00:00:00Z"), content: "MaySecond", income: 0, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-06-01T00:00:00Z"), content: "June", income: 0, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-05-02T00:00:00Z"), content: "MaySecond", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-06-01T00:00:00Z"), content: "June", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsAfter(cutoff)
         let items = try service.items(.items(predicate))
@@ -203,7 +203,7 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try service.create(date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsAfter(cutoff)
         let items = try service.items(.items(predicate))
@@ -217,8 +217,8 @@ struct ItemPredicateTest {
     func excludesDifferentYearSameMonth(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(date: shiftedDate("2023-02-15T00:00:00Z"), content: "2023Feb", income: 0, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-02-15T00:00:00Z"), content: "2024Feb", income: 0, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2023-02-15T00:00:00Z"), content: "2023Feb", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-02-15T00:00:00Z"), content: "2024Feb", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-02-01T00:00:00Z"))
         let items = try service.items(.items(predicate))
@@ -232,9 +232,9 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let baseDate = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try service.create(date: shiftedDate("2024-01-15T00:00:00Z"), content: "January", income: 0, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-06-01T00:00:00Z"), content: "June", income: 0, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2023-12-31T23:59:59Z"), content: "LastYear", income: 0, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-01-15T00:00:00Z"), content: "January", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-06-01T00:00:00Z"), content: "June", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2023-12-31T23:59:59Z"), content: "LastYear", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameYearAs(baseDate)
         let items = try service.items(.items(predicate))
@@ -251,12 +251,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try service.create(
-            date: jstDate,
-            content: "JST_Jan1",
-            income: 0,
-            outgo: 0,
-            category: "TZBoundary"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JST_Jan1",
+             income: 0,
+             outgo: 0,
+             category: "TZBoundary",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-01-01T00:00:00Z"))
@@ -271,12 +273,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-12-31T23:59:59Z") // UTC: 2024-12-31T14:59:59Z
-        _ = try service.create(
-            date: jstDate,
-            content: "JST_EndOfYear",
-            income: 0,
-            outgo: 0,
-            category: "Test"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JST_EndOfYear",
+             income: 0,
+             outgo: 0,
+             category: "Test",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-01-01T00:00:00Z"))
@@ -291,12 +295,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-01-01T00:00:00Z") // UTC: 2023-12-31T15:00:00Z
-        _ = try service.create(
-            date: jstDate,
-            content: "JST_StartOfYear",
-            income: 0,
-            outgo: 0,
-            category: "Test"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JST_StartOfYear",
+             income: 0,
+             outgo: 0,
+             category: "Test",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-01-01T00:00:00Z"))
@@ -312,19 +318,23 @@ struct ItemPredicateTest {
         let jstDate1 = shiftedDate("2024-01-01T00:00:00Z")  // 2023-12-31T15:00:00Z
         let jstDate2 = shiftedDate("2024-12-31T23:59:59Z")  // 2024-12-31T14:59:59Z
 
-        _ = try service.create(
-            date: jstDate1,
-            content: "StartJSTYear",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate1,
+             content: "StartJSTYear",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
-        _ = try service.create(
-            date: jstDate2,
-            content: "EndJSTYear",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate2,
+             content: "EndJSTYear",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-01-01T00:00:00Z"))
@@ -341,12 +351,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-03-01T00:00:00Z")  // = 2024-02-29T15:00:00Z
-        _ = try service.create(
-            date: jstDate,
-            content: "JST_MarchStart",
-            income: 0,
-            outgo: 0,
-            category: "Test"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JST_MarchStart",
+             income: 0,
+             outgo: 0,
+             category: "Test",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-03-01T00:00:00Z"))
@@ -359,12 +371,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let utcDate = shiftedDate("2024-03-01T00:00:00Z")
-        _ = try service.create(
-            date: utcDate,
-            content: "UTC_MarchStart",
-            income: 0,
-            outgo: 0,
-            category: "Test"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: utcDate,
+             content: "UTC_MarchStart",
+             income: 0,
+             outgo: 0,
+             category: "Test",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-03-01T00:00:00Z"))
@@ -378,12 +392,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-02-01T00:00:00Z")
-        _ = try service.create(
-            date: jstDate,
-            content: "JSTFebStart",
-            income: 100,
-            outgo: 0,
-            category: "TZBoundary"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JSTFebStart",
+             income: 100,
+             outgo: 0,
+             category: "TZBoundary",
+             repeatCount: 1)
         )
         let jan = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-01-01T00:00:00Z"))
         let feb = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
@@ -398,12 +414,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-03-01T00:00:00Z")
-        _ = try service.create(
-            date: jstDate,
-            content: "JSTMarStart",
-            income: 100,
-            outgo: 0,
-            category: "TZBoundary"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JSTMarStart",
+             income: 100,
+             outgo: 0,
+             category: "TZBoundary",
+             repeatCount: 1)
         )
         let feb = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
         let mar = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-03-01T00:00:00Z"))
@@ -419,12 +437,14 @@ struct ItemPredicateTest {
 
         // 2024-02-29T23:59:59+0900 = 2024-02-29T14:59:59Z
         let jstDate = shiftedDate("2024-02-29T23:59:59Z")
-        _ = try service.create(
-            date: jstDate,
-            content: "JSTEnd",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JSTEnd",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
@@ -439,12 +459,14 @@ struct ItemPredicateTest {
 
         // 2024-02-01T00:00:00+0900 = 2024-01-31T15:00:00Z
         let jstDate = shiftedDate("2024-02-01T00:00:00Z")
-        _ = try service.create(
-            date: jstDate,
-            content: "JSTBoundary",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JSTBoundary",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
@@ -459,26 +481,32 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         // Insert three items, one at start, one in middle, one at end of February (UTC)
-        _ = try service.create(
-            date: shiftedDate("2024-02-01T00:00:00Z"),
-            content: "StartOfMonth",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: shiftedDate("2024-02-01T00:00:00Z"),
+             content: "StartOfMonth",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
-        _ = try service.create(
-            date: shiftedDate("2024-02-14T12:00:00Z"),
-            content: "MidMonth",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: shiftedDate("2024-02-14T12:00:00Z"),
+             content: "MidMonth",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
-        _ = try service.create(
-            date: shiftedDate("2024-02-29T23:59:59Z"),
-            content: "EndOfMonth",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: shiftedDate("2024-02-29T23:59:59Z"),
+             content: "EndOfMonth",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
@@ -498,19 +526,23 @@ struct ItemPredicateTest {
         let jstDate1 = shiftedDate("2024-03-01T00:00:00Z")  // 2024-02-29T15:00:00Z
         let jstDate2 = shiftedDate("2024-03-31T23:59:59Z")  // 2024-03-31T14:59:59Z
 
-        _ = try service.create(
-            date: jstDate1,
-            content: "StartJST",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate1,
+             content: "StartJST",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
-        _ = try service.create(
-            date: jstDate2,
-            content: "EndJST",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate2,
+             content: "EndJST",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-03-01T00:00:00Z"))
@@ -525,10 +557,10 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let baseDate = shiftedDate("2024-04-01T00:00:00Z")
-        _ = try service.create(date: baseDate, content: "TargetDay", income: 1, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-04-01T23:59:59Z"), content: "EndSameDay", income: 1, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-03-31T23:59:59Z"), content: "DayBefore", income: 1, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-04-02T00:00:00Z"), content: "DayAfter", income: 1, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: baseDate, content: "TargetDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-04-01T23:59:59Z"), content: "EndSameDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-03-31T23:59:59Z"), content: "DayBefore", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-04-02T00:00:00Z"), content: "DayAfter", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameDayAs(baseDate)
         let items = try service.items(.items(predicate))
@@ -548,19 +580,23 @@ struct ItemPredicateTest {
         let jstDate1 = shiftedDate("2024-04-01T00:00:00Z")  // 2024-03-31T15:00:00Z
         let jstDate2 = shiftedDate("2024-04-01T23:59:59Z")  // 2024-04-01T15:00:00Z
 
-        _ = try service.create(
-            date: jstDate1,
-            content: "StartJSTDay",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate1,
+             content: "StartJSTDay",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
-        _ = try service.create(
-            date: jstDate2,
-            content: "EndJSTDay",
-            income: 100,
-            outgo: 0,
-            category: "TZTest"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate2,
+             content: "EndJSTDay",
+             income: 100,
+             outgo: 0,
+             category: "TZTest",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameDayAs(shiftedDate("2024-04-01T00:00:00Z"))
@@ -577,8 +613,8 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let baseDate = shiftedDate("2024-04-01T00:00:00Z")
-        _ = try service.create(date: shiftedDate("2024-03-31T00:00:00Z"), content: "PrevDay", income: 1, outgo: 0, category: "Test")
-        _ = try service.create(date: shiftedDate("2024-04-02T00:00:00Z"), content: "NextDay", income: 1, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-03-31T00:00:00Z"), content: "PrevDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-04-02T00:00:00Z"), content: "NextDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameDayAs(baseDate)
         let items = try service.items(.items(predicate))
@@ -595,7 +631,7 @@ struct ItemPredicateTest {
 
         let baseDate = shiftedDate("2024-04-01T00:00:00Z")
         let endOfDay = shiftedDate("2024-04-01T23:59:59Z")
-        _ = try service.create(date: endOfDay, content: "EndOfDay", income: 1, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: endOfDay, content: "EndOfDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameDayAs(baseDate)
         let items = try service.items(.items(predicate))
@@ -609,7 +645,7 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let baseDate = shiftedDate("2024-04-01T00:00:00Z")
-        _ = try service.create(date: shiftedDate("2024-04-02T00:00:00Z"), content: "NextDayStart", income: 1, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-04-02T00:00:00Z"), content: "NextDayStart", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameDayAs(baseDate)
         let items = try service.items(.items(predicate))
@@ -622,12 +658,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try service.create(
-            date: jstDate,
-            content: "JST_Jan1",
-            income: 0,
-            outgo: 0,
-            category: "TZBoundary"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JST_Jan1",
+             income: 0,
+             outgo: 0,
+             category: "TZBoundary",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameDayAs(shiftedDate("2024-01-01T00:00:00Z"))
@@ -641,12 +679,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-04-02T00:00:00Z") // UTC: 2024-04-01T15:00:00Z
-        _ = try service.create(
-            date: jstDate,
-            content: "JST_NextDay",
-            income: 0,
-            outgo: 0,
-            category: "Test"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JST_NextDay",
+             income: 0,
+             outgo: 0,
+             category: "Test",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameDayAs(shiftedDate("2024-04-01T00:00:00Z"))
@@ -660,12 +700,14 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-04-01T00:00:00Z") // UTC: 2024-03-31T15:00:00Z
-        _ = try service.create(
-            date: jstDate,
-            content: "JST_StartOfDay",
-            income: 0,
-            outgo: 0,
-            category: "Test"
+        _ = try CreateItemIntent.perform(
+            (context: context,
+             date: jstDate,
+             content: "JST_StartOfDay",
+             income: 0,
+             outgo: 0,
+             category: "Test",
+             repeatCount: 1)
         )
 
         let predicate = ItemPredicate.dateIsSameDayAs(shiftedDate("2024-03-31T00:00:00Z"))
@@ -681,8 +723,8 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let date = shiftedDate("2024-06-01T00:00:00Z")
-        _ = try service.create(date: date, content: "Match", income: 0, outgo: 5_000, category: "Test")
-        _ = try service.create(date: date, content: "Low", income: 0, outgo: 4_999, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: date, content: "Match", income: 0, outgo: 5_000, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: date, content: "Low", income: 0, outgo: 4_999, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.outgoIsGreaterThanOrEqualTo(amount: 5_000, onOrAfter: date)
         let items = try service.items(.items(predicate))
@@ -696,8 +738,8 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoffDate = shiftedDate("2024-06-01T00:00:00Z")
-        _ = try service.create(date: shiftedDate("2024-05-31T23:59:59Z"), content: "Early", income: 0, outgo: 10_000, category: "Test")
-        _ = try service.create(date: cutoffDate, content: "Valid", income: 0, outgo: 10_000, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-05-31T23:59:59Z"), content: "Early", income: 0, outgo: 10_000, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((context: context, date: cutoffDate, content: "Valid", income: 0, outgo: 10_000, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.outgoIsGreaterThanOrEqualTo(amount: 5_000, onOrAfter: cutoffDate)
         let items = try service.items(.items(predicate))
@@ -712,10 +754,10 @@ struct ItemPredicateTest {
     func includesItemsWithRepeatID(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(date: shiftedDate("2024-01-01T00:00:00Z"), content: "RepeatOne", income: 0, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-01-01T00:00:00Z"), content: "RepeatOne", income: 0, outgo: 0, category: "Test", repeatCount: 1))
         let repeatID = try service.item()!.repeatID
 
-        _ = try service.create(date: shiftedDate("2024-02-01T00:00:00Z"), content: "NonRepeat", income: 0, outgo: 0, category: "Test")
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-02-01T00:00:00Z"), content: "NonRepeat", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.repeatIDIs(repeatID)
         let items = try service.items(.items(predicate))
@@ -728,7 +770,7 @@ struct ItemPredicateTest {
     func includesOnlyFutureRepeatItems(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(date: shiftedDate("2024-01-01T00:00:00Z"), content: "Past", income: 0, outgo: 0, category: "Test", repeatCount: 2)
+        _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-01-01T00:00:00Z"), content: "Past", income: 0, outgo: 0, category: "Test", repeatCount: 2))
         let repeatID = try service.item()!.repeatID
 
         let predicate = ItemPredicate.repeatIDAndDateIsAfter(repeatID: repeatID, date: shiftedDate("2024-02-01T00:00:00Z"))

--- a/IncomesTests/TimeZone/ItemServiceTest.swift
+++ b/IncomesTests/TimeZone/ItemServiceTest.swift
@@ -21,13 +21,33 @@ struct ItemServiceTest {
         service = .init(context: context)
     }
 
+    @discardableResult
+    func createItem(date: Date,
+                    content: String,
+                    income: Decimal,
+                    outgo: Decimal,
+                    category: String,
+                    repeatCount: Int = 1) throws -> ItemEntity {
+        try CreateItemIntent.perform(
+            (
+                context: context,
+                date: date,
+                content: content,
+                income: income,
+                outgo: outgo,
+                category: category,
+                repeatCount: repeatCount
+            )
+        )
+    }
+
     // MARK: - Fetch
 
     @Test("item returns first item if available", arguments: timeZones)
     func item(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "First",
             income: 100,
@@ -42,14 +62,14 @@ struct ItemServiceTest {
     func itemWithPredicate(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Food",
             income: 0,
             outgo: 500,
             category: "Food"
         )
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Transport",
             income: 0,
@@ -65,14 +85,14 @@ struct ItemServiceTest {
     func items(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "One",
             income: 100,
             outgo: 0,
             category: "Test"
         )
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-02T00:00:00Z"),
             content: "Two",
             income: 200,
@@ -87,14 +107,14 @@ struct ItemServiceTest {
     func itemsWithPredicate(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Match",
             income: 0,
             outgo: 800,
             category: "Filtered"
         )
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "NoMatch",
             income: 0,
@@ -111,7 +131,7 @@ struct ItemServiceTest {
     func itemsCount(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Only",
             income: 300,
@@ -126,14 +146,14 @@ struct ItemServiceTest {
     func itemsCountWithPredicate(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "X",
             income: 0,
             outgo: 900,
             category: "Filtered"
         )
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Y",
             income: 0,
@@ -151,7 +171,7 @@ struct ItemServiceTest {
     func create(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Lunch",
             income: 1_000,
@@ -166,7 +186,7 @@ struct ItemServiceTest {
     func createWithRepeat(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Rent",
             income: 0,
@@ -183,7 +203,7 @@ struct ItemServiceTest {
     func createWithZeroRepeat(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-03-01T00:00:00Z"),
             content: "Single",
             income: 100,
@@ -200,7 +220,7 @@ struct ItemServiceTest {
     func createWithZeroAmounts(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-03-01T00:00:00Z"),
             content: "Neutral",
             income: 0,
@@ -216,7 +236,7 @@ struct ItemServiceTest {
         NSTimeZone.default = timeZone
 
         for _ in 0..<2 {
-            _ = try service.create(
+            _ = try createItem(
                 date: isoDate("2024-03-01T00:00:00Z"),
                 content: "Repeated",
                 income: 100,
@@ -234,7 +254,7 @@ struct ItemServiceTest {
         NSTimeZone.default = timeZone
 
         let boundaryDate = shiftedDate("2024-03-15T00:00:00Z")
-        _ = try service.create(
+        _ = try createItem(
             date: boundaryDate,
             content: "MidnightUTC",
             income: 100,
@@ -250,7 +270,7 @@ struct ItemServiceTest {
         NSTimeZone.default = timeZone
 
         let jstDate = shiftedDate("2024-03-15T09:00:00Z")  // 00:00 UTC
-        _ = try service.create(
+        _ = try createItem(
             date: jstDate,
             content: "JSTToUTC",
             income: 100,
@@ -267,7 +287,7 @@ struct ItemServiceTest {
 
         let inputDate = isoDate("2024-03-15T10:30:00Z")
         let expectedDate = Calendar.utc.startOfDay(for: inputDate)
-        _ = try service.create(
+        _ = try createItem(
             date: inputDate,
             content: "RoundedTime",
             income: 100,
@@ -284,7 +304,7 @@ struct ItemServiceTest {
     func update(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: shiftedDate("2024-01-01T00:00:00Z"),
             content: "Initial",
             income: 100,
@@ -310,7 +330,7 @@ struct ItemServiceTest {
     func updateAssignsNewRepeatID(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Initial",
             income: 100,
@@ -336,14 +356,14 @@ struct ItemServiceTest {
     func updateChangesDateOrdering(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "First",
             income: 100,
             outgo: 0,
             category: "SortTest"
         )
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-02T00:00:00Z"),
             content: "Second",
             income: 100,
@@ -370,7 +390,7 @@ struct ItemServiceTest {
     func updateForFutureItems(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Subscription",
             income: 0,
@@ -400,7 +420,7 @@ struct ItemServiceTest {
     func updateFutureLastOnly(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Monthly",
             income: 100,
@@ -429,7 +449,7 @@ struct ItemServiceTest {
     func updateFutureSingleRepeat(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Solo",
             income: 0,
@@ -454,7 +474,7 @@ struct ItemServiceTest {
     func updateForAllItems(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-02-01T00:00:00Z"),
             content: "Gym",
             income: 0,
@@ -486,7 +506,7 @@ struct ItemServiceTest {
     func delete(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-04-01T00:00:00Z"),
             content: "ToDelete",
             income: 100,
@@ -511,14 +531,14 @@ struct ItemServiceTest {
     func deleteMultipleItems(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "KeepMe",
             income: 100,
             outgo: 0,
             category: "General"
         )
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-02T00:00:00Z"),
             content: "RemoveMe",
             income: 100,
@@ -538,7 +558,7 @@ struct ItemServiceTest {
     func deleteAll(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "DeleteMe",
             income: 0,
@@ -556,7 +576,7 @@ struct ItemServiceTest {
     func recalculate(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "AdjustMe",
             income: 100,
@@ -580,7 +600,7 @@ struct ItemServiceTest {
     func recalculateNoChange(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Stable",
             income: 100,
@@ -600,14 +620,14 @@ struct ItemServiceTest {
     func recalculatePartial(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-01-01T00:00:00Z"),
             content: "Before",
             income: 100,
             outgo: 50,
             category: "Split"
         )
-        _ = try service.create(
+        _ = try createItem(
             date: isoDate("2024-02-01T00:00:00Z"),
             content: "After",
             income: 200,
@@ -634,14 +654,14 @@ struct ItemServiceTest {
     func recalculateWithTimeZoneBoundaries(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try service.create(
+        _ = try createItem(
             date: shiftedDate("2024-02-28T15:00:00Z"),  // JST: 2024-02-29 00:00
             content: "EarlyMar",
             income: 300,
             outgo: 50,
             category: "TZTest"
         )
-        _ = try service.create(
+        _ = try createItem(
             date: shiftedDate("2024-02-28T14:00:00Z"),  // JST: 2024-02-28 23:00
             content: "LateFeb",
             income: 500,


### PR DESCRIPTION
## Summary
- remove `ItemService.create` implementation
- implement item creation in `CreateItemIntent`
- update `CreateAndShowItemIntent` and `ItemFormView` to pass a model context
- migrate tests to use `CreateItemIntent` for creating items
- add dedicated tests for `CreateItemIntent` using the Testing framework
- receive a `ModelContext` parameter when creating items
- ensure context is always the first parameter

## Testing
- `swiftlint --version` *(fails: command not found)*
- `swift test -c debug` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68510fd025f083209384f320546c8909