### PR TITLE
Refine error design

### DIFF
--- a/Incomes/Sources/AppIntent/Intent/Create/CreateAndShowItemIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Create/CreateAndShowItemIntent.swift
@@ -34,7 +34,7 @@ struct CreateAndShowItemIntent: AppIntent, IntentPerformer, @unchecked Sendable 
     static func perform(_ input: Input) throws -> Output {
         let (context, date, content, income, outgo, category, repeatCount) = input
         guard content.isNotEmpty else {
-            throw DebugError.default
+            throw ItemError.contentIsEmpty
         }
         return try CreateItemIntent.perform(
             (

--- a/Incomes/Sources/AppIntent/Intent/Create/CreateItemIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Create/CreateItemIntent.swift
@@ -77,7 +77,7 @@ struct CreateItemIntent: AppIntent, IntentPerformer, @unchecked Sendable {
         try calculator.calculate(for: items)
 
         guard let entity = ItemEntity(model) else {
-            throw DebugError.default
+            throw ItemError.entityConversionFailed
         }
         return entity
     }

--- a/Incomes/Sources/AppIntent/Intent/Delete/DeleteItemIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Delete/DeleteItemIntent.swift
@@ -19,7 +19,7 @@ struct DeleteItemIntent: AppIntent, IntentPerformer, @unchecked Sendable {
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
             let model = try context.fetchFirst(.items(.idIs(id)))
         else {
-            throw DebugError.default
+            throw ItemError.itemNotFound
         }
         model.delete()
         let calculator = BalanceCalculator(context: context)

--- a/Incomes/Sources/Item/Model/ItemError.swift
+++ b/Incomes/Sources/Item/Model/ItemError.swift
@@ -1,0 +1,26 @@
+//
+//  ItemError.swift
+//  Incomes
+//
+//  Created by Hiromu Nakano on 2025/06/12.
+//  Copyright © 2025 Hiromu Nakano. All rights reserved.
+//
+
+import Foundation
+
+enum ItemError: IncomesError {
+    case contentIsEmpty
+    case entityConversionFailed
+    case itemNotFound
+
+    var resource: LocalizedStringResource {
+        switch self {
+        case .contentIsEmpty:
+            return .init(stringLiteral: "Content is empty")
+        case .entityConversionFailed:
+            return .init(stringLiteral: "Failed to convert item entity")
+        case .itemNotFound:
+            return .init(stringLiteral: "Item not found")
+        }
+    }
+}

--- a/Incomes/Sources/Item/Model/ItemService.swift
+++ b/Incomes/Sources/Item/Model/ItemService.swift
@@ -31,7 +31,7 @@ final class ItemService {
 
     func model(of entity: ItemEntity) throws -> Item {
         guard let model = try item(.items(.idIs(.init(base64Encoded: entity.id)))) else {
-            throw DebugError.default
+            throw ItemError.itemNotFound
         }
         return model
     }


### PR DESCRIPTION
## Summary
- introduce `ItemError` and migrate to explicit failures
- replace `DebugError.default` with relevant `ItemError` cases

## Testing
- `pre-commit run --files Incomes/Sources/AppIntent/Intent/Create/CreateAndShowItemIntent.swift Incomes/Sources/AppIntent/Intent/Create/CreateItemIntent.swift Incomes/Sources/AppIntent/Intent/Delete/DeleteItemIntent.swift Incomes/Sources/Item/Model/ItemService.swift Incomes/Sources/Item/Model/ItemError.swift`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512ba20e2483208e69a0fa1880041b