### PR TITLE
Add TagEntity model for AppIntents

### DIFF
--- a/Incomes/Sources/AppIntent/Model/TagEntity.swift
+++ b/Incomes/Sources/AppIntent/Model/TagEntity.swift
@@ -1,0 +1,80 @@
+//
+//  TagEntity.swift
+//  Incomes
+//
+//  Created by Hiromu Nakano on 2025/05/24.
+//  Copyright © 2025 Hiromu Nakano. All rights reserved.
+//
+
+import AppIntents
+
+@Observable
+final class TagEntity: AppEntity {
+    static let defaultQuery = TagEntityQuery()
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        .init(
+            name: .init("Tag", table: "AppIntents"),
+            numericFormat: LocalizedStringResource("\(placeholder: .int) Tags", table: "AppIntents")
+        )
+    }
+
+    var displayRepresentation: DisplayRepresentation {
+        .init(
+            title: .init("\(displayName)", table: "AppIntents"),
+            image: .init(systemName: "tag.fill"),
+            synonyms: [
+                .init("\(name)", table: "AppIntents")
+            ]
+        )
+    }
+
+    let id: String
+    let name: String
+    let typeID: String
+
+    init(id: String, name: String, typeID: String) {
+        self.id = id
+        self.name = name
+        self.typeID = typeID
+    }
+}
+
+// MARK: - ModelBridgeable
+
+extension TagEntity: ModelBridgeable {
+    typealias Model = Tag
+
+    convenience init?(_ model: Tag) {
+        guard let encodedID = try? model.id.base64Encoded() else {
+            return nil
+        }
+        self.init(
+            id: encodedID,
+            name: model.name,
+            typeID: model.typeID
+        )
+    }
+}
+
+extension TagEntity {
+    var type: Tag.TagType? {
+        Tag.TagType(rawValue: typeID)
+    }
+
+    var displayName: String {
+        switch type {
+        case .year:
+            name.dateValueWithoutLocale(.yyyy)?.stringValue(.yyyy) ?? name
+        case .yearMonth:
+            name.dateValueWithoutLocale(.yyyyMM)?.stringValue(.yyyyMMM) ?? name
+        case .content:
+            name
+        case .category:
+            name.isNotEmpty ? name : "Others"
+        case .none:
+            name
+        }
+    }
+}
+

--- a/Incomes/Sources/AppIntent/Model/TagEntityQuery.swift
+++ b/Incomes/Sources/AppIntent/Model/TagEntityQuery.swift
@@ -1,0 +1,53 @@
+//
+//  TagEntityQuery.swift
+//  Incomes
+//
+//  Created by Hiromu Nakano on 2025/05/24.
+//  Copyright © 2025 Hiromu Nakano. All rights reserved.
+//
+
+import AppIntents
+
+struct TagEntityQuery: EntityStringQuery, @unchecked Sendable {
+    @Dependency private var tagService: TagService
+
+    func entities(for identifiers: [TagEntity.ID]) throws -> [TagEntity] {
+        try identifiers.compactMap { id in
+            try tagService.tag(
+                .tags(.idIs(try .init(base64Encoded: id)))
+            )
+        }
+        .compactMap(TagEntity.init)
+    }
+
+    func entities(matching string: String) throws -> [TagEntity] {
+        try [
+            Tag.TagType.year,
+            .yearMonth,
+            .content,
+            .category
+        ]
+        .compactMap { type in
+            try tagService.tag(
+                .tags(.nameContains(string, type: type))
+            )
+        }
+        .compactMap(TagEntity.init)
+    }
+
+    func suggestedEntities() throws -> [TagEntity] {
+        try [
+            Tag.TagType.year,
+            .yearMonth,
+            .content,
+            .category
+        ]
+        .compactMap { type in
+            try tagService.tag(
+                .tags(.typeIs(type))
+            )
+        }
+        .compactMap(TagEntity.init)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add new `TagEntity` model to mirror `ItemEntity`
- support query logic with `TagEntityQuery`

## Testing
- `pre-commit` *(fails: GitHub fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68512ca92ab08320b0ff945b39d85365