### PR TITLE
Migrate TagService get methods to AppIntents

### DIFF
--- a/Incomes/Resources/AppIntents.xcstrings
+++ b/Incomes/Resources/AppIntents.xcstrings
@@ -257,6 +257,9 @@
     "Get All Items Count" : {
 
     },
+    "Get All Tags" : {
+
+    },
     "Get Items" : {
       "localizations" : {
         "en" : {
@@ -632,6 +635,12 @@
       }
     },
     "Get Repeat Items Count" : {
+
+    },
+    "Get Tag By ID" : {
+
+    },
+    "Get Tag By Name" : {
 
     },
     "Get Year Items Count" : {

--- a/Incomes/Resources/Localizable.xcstrings
+++ b/Incomes/Resources/Localizable.xcstrings
@@ -3428,7 +3428,13 @@
     "Tag" : {
 
     },
+    "Tag ID" : {
+
+    },
     "Tag not found" : {
+
+    },
+    "Tag Type" : {
 
     },
     "Tags" : {
@@ -4008,6 +4014,9 @@
           }
         }
       }
+    },
+    "Year/Month" : {
+
     },
     "YearMonth" : {
       "localizations" : {

--- a/Incomes/Sources/AppIntent/Intent/Get/GetAllTagsIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Get/GetAllTagsIntent.swift
@@ -1,0 +1,22 @@
+import AppIntents
+import SwiftData
+import SwiftUtilities
+
+struct GetAllTagsIntent: AppIntent, IntentPerformer {
+    static let title: LocalizedStringResource = .init("Get All Tags", table: "AppIntents")
+
+    @Dependency private var modelContainer: ModelContainer
+
+    typealias Input = ModelContext
+    typealias Output = [Tag]
+
+    static func perform(_ input: Input) throws -> Output {
+        try input.fetch(.tags(.all))
+    }
+
+    @MainActor
+    func perform() throws -> some ReturnsValue<[TagEntity]> {
+        let tags = try Self.perform(modelContainer.mainContext)
+        return .result(value: tags.compactMap(TagEntity.init))
+    }
+}

--- a/Incomes/Sources/AppIntent/Intent/Get/GetTagByIDIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Get/GetTagByIDIntent.swift
@@ -1,0 +1,23 @@
+import AppIntents
+import SwiftData
+import SwiftUtilities
+
+struct GetTagByIDIntent: AppIntent, IntentPerformer {
+    static let title: LocalizedStringResource = .init("Get Tag By ID", table: "AppIntents")
+
+    @Dependency private var modelContainer: ModelContainer
+
+    typealias Input = (context: ModelContext, id: PersistentIdentifier)
+    typealias Output = Tag?
+
+    static func perform(_ input: Input) throws -> Output {
+        try input.context.fetchFirst(
+            .tags(.idIs(input.id))
+        )
+    }
+
+    @MainActor
+    func perform() throws -> some ReturnsValue<TagEntity?> {
+        fatalError("This intent is designed for programmatic use only")
+    }
+}

--- a/Incomes/Sources/AppIntent/Intent/Get/GetTagByIDIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Get/GetTagByIDIntent.swift
@@ -5,6 +5,9 @@ import SwiftUtilities
 struct GetTagByIDIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Tag By ID", table: "AppIntents")
 
+    @Parameter(title: "Tag ID")
+    var id: String
+
     @Dependency private var modelContainer: ModelContainer
 
     typealias Input = (context: ModelContext, id: PersistentIdentifier)
@@ -18,6 +21,11 @@ struct GetTagByIDIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<TagEntity?> {
-        fatalError("This intent is designed for programmatic use only")
+        guard let persistentID = try? PersistentIdentifier(base64Encoded: id),
+              let tag = try Self.perform((context: modelContainer.mainContext, id: persistentID)),
+              let tagEntity = TagEntity(tag) else {
+            return .result(value: nil)
+        }
+        return .result(value: tagEntity)
     }
 }

--- a/Incomes/Sources/AppIntent/Intent/Get/GetTagByNameIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Get/GetTagByNameIntent.swift
@@ -8,11 +8,11 @@ struct GetTagByNameIntent: AppIntent, IntentPerformer {
     @Parameter(title: "Name")
     private var name: String
     @Parameter(title: "Type")
-    private var type: Tag.TagType
+    private var type: TagType
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, name: String, type: Tag.TagType)
+    typealias Input = (context: ModelContext, name: String, type: TagType)
     typealias Output = Tag?
 
     static func perform(_ input: Input) throws -> Output {

--- a/Incomes/Sources/AppIntent/Intent/Get/GetTagByNameIntent.swift
+++ b/Incomes/Sources/AppIntent/Intent/Get/GetTagByNameIntent.swift
@@ -1,0 +1,31 @@
+import AppIntents
+import SwiftData
+import SwiftUtilities
+
+struct GetTagByNameIntent: AppIntent, IntentPerformer {
+    static let title: LocalizedStringResource = .init("Get Tag By Name", table: "AppIntents")
+
+    @Parameter(title: "Name")
+    private var name: String
+    @Parameter(title: "Type")
+    private var type: Tag.TagType
+
+    @Dependency private var modelContainer: ModelContainer
+
+    typealias Input = (context: ModelContext, name: String, type: Tag.TagType)
+    typealias Output = Tag?
+
+    static func perform(_ input: Input) throws -> Output {
+        try input.context.fetchFirst(
+            .tags(.nameIs(input.name, type: input.type))
+        )
+    }
+
+    @MainActor
+    func perform() throws -> some ReturnsValue<TagEntity?> {
+        let tag = try Self.perform(
+            (context: modelContainer.mainContext, name: name, type: type)
+        )
+        return .result(value: tag.flatMap(TagEntity.init))
+    }
+}

--- a/Incomes/Sources/AppIntent/Model/TagEntity.swift
+++ b/Incomes/Sources/AppIntent/Model/TagEntity.swift
@@ -59,8 +59,8 @@ extension TagEntity: ModelBridgeable {
 }
 
 extension TagEntity {
-    var type: Tag.TagType? {
-        Tag.TagType(rawValue: typeID)
+    var type: TagType? {
+        TagType(rawValue: typeID)
     }
 
     var displayName: String {

--- a/Incomes/Sources/AppIntent/Model/TagEntityQuery.swift
+++ b/Incomes/Sources/AppIntent/Model/TagEntityQuery.swift
@@ -12,6 +12,7 @@ import SwiftData
 struct TagEntityQuery: EntityStringQuery, @unchecked Sendable {
     @Dependency private var modelContainer: ModelContainer
 
+    @MainActor
     func entities(for identifiers: [TagEntity.ID]) throws -> [TagEntity] {
         try identifiers.compactMap { id in
             try GetTagByIDIntent.perform(
@@ -24,12 +25,13 @@ struct TagEntityQuery: EntityStringQuery, @unchecked Sendable {
         .compactMap(TagEntity.init)
     }
 
+    @MainActor
     func entities(matching string: String) throws -> [TagEntity] {
         let tags = try GetAllTagsIntent.perform(modelContainer.mainContext)
         let hiragana = string.applyingTransform(.hiraganaToKatakana, reverse: true).orEmpty
         let katakana = string.applyingTransform(.hiraganaToKatakana, reverse: false).orEmpty
         return [
-            Tag.TagType.year,
+            TagType.year,
             .yearMonth,
             .content,
             .category
@@ -47,10 +49,11 @@ struct TagEntityQuery: EntityStringQuery, @unchecked Sendable {
         .compactMap(TagEntity.init)
     }
 
+    @MainActor
     func suggestedEntities() throws -> [TagEntity] {
         let tags = try GetAllTagsIntent.perform(modelContainer.mainContext)
         return [
-            Tag.TagType.year,
+            TagType.year,
             .yearMonth,
             .content,
             .category
@@ -61,4 +64,3 @@ struct TagEntityQuery: EntityStringQuery, @unchecked Sendable {
         .compactMap(TagEntity.init)
     }
 }
-

--- a/Incomes/Sources/Debug/View/DebugListView.swift
+++ b/Incomes/Sources/Debug/View/DebugListView.swift
@@ -35,7 +35,7 @@ extension DebugListView: View {
                     Text("Debug option")
                 }
             }
-            if let tag = try? tagService.tag() {
+            if let tag = try? GetAllTagsIntent.perform(context).first {
                 Section {
                     NavigationLink(value: IncomesPath.itemList(tag)) {
                         Text("All Items")

--- a/Incomes/Sources/Home/View/HomeListView.swift
+++ b/Incomes/Sources/Home/View/HomeListView.swift
@@ -83,7 +83,13 @@ extension HomeListView: View {
         .task {
             if !hasLoaded {
                 hasLoaded = true
-                yearTag = try? tagService.tag(.tags(.nameIs(Date.now.stringValueWithoutLocale(.yyyy), type: .year)))
+                yearTag = try? GetTagByNameIntent.perform(
+                    (
+                        context: context,
+                        name: Date.now.stringValueWithoutLocale(.yyyy),
+                        type: .year
+                    )
+                )
                 isIntroductionPresented = (
                     try? GetAllItemsCountIntent.perform(context).isZero
                 ) ?? false

--- a/Incomes/Sources/Item/Component/SuggestionButtonGroup.swift
+++ b/Incomes/Sources/Item/Component/SuggestionButtonGroup.swift
@@ -13,7 +13,7 @@ struct SuggestionButtonGroup: View {
 
     @Binding private var input: String
 
-    init(input: Binding<String>, type: Tag.TagType) {
+    init(input: Binding<String>, type: TagType) {
         _input = input
         _suggestions = .init(.tags(.nameContains(input.wrappedValue, type: type)))
     }

--- a/Incomes/Sources/Tag/Model/Tag.swift
+++ b/Incomes/Sources/Tag/Model/Tag.swift
@@ -11,13 +11,6 @@ import SwiftData
 
 @Model
 final class Tag {
-    enum TagType: String {
-        case year = "aae8af65"
-        case yearMonth = "27c9be4b"
-        case content = "e2d390d9"
-        case category = "a7a130f4"
-    }
-
     private(set) var name = String.empty
     private(set) var typeID = String.empty
 
@@ -25,7 +18,7 @@ final class Tag {
 
     private init() {}
 
-    static func create(context: ModelContext, name: String, type: Tag.TagType) throws -> Tag {
+    static func create(context: ModelContext, name: String, type: TagType) throws -> Tag {
         let tag = try context.fetchFirst(.tags(.nameIs(name, type: type))) ?? .init()
         context.insert(tag)
         tag.name = name
@@ -60,7 +53,7 @@ extension Tag: Identifiable {}
 // MARK: - Test
 
 extension Tag {
-    static func createIgnoringDuplicates(context: ModelContext, name: String, type: Tag.TagType) throws -> Tag {
+    static func createIgnoringDuplicates(context: ModelContext, name: String, type: TagType) throws -> Tag {
         let tag = Tag()
         context.insert(tag)
         tag.name = name

--- a/Incomes/Sources/Tag/Model/TagPredicate.swift
+++ b/Incomes/Sources/Tag/Model/TagPredicate.swift
@@ -14,10 +14,10 @@ enum TagPredicate {
     case none
     case idIs(Tag.ID)
     case isSameWith(Tag)
-    case typeIs(Tag.TagType)
-    case nameIs(String, type: Tag.TagType)
-    case nameContains(String, type: Tag.TagType)
-    case nameStartsWith(String, type: Tag.TagType)
+    case typeIs(TagType)
+    case nameIs(String, type: TagType)
+    case nameContains(String, type: TagType)
+    case nameStartsWith(String, type: TagType)
 
     var value: Predicate<Tag> {
         switch self {

--- a/Incomes/Sources/Tag/Model/TagService.swift
+++ b/Incomes/Sources/Tag/Model/TagService.swift
@@ -19,11 +19,6 @@ final class TagService {
         self.context = context
     }
 
-    // MARK: - Fetch
-
-    func tag(_ descriptor: FetchDescriptor<Tag> = .tags(.all)) throws -> Tag? {
-        try context.fetchFirst(descriptor)
-    }
 
     // MARK: - Duplicates
 
@@ -52,11 +47,10 @@ final class TagService {
 
     func resolveAllDuplicates(in tags: [Tag]) throws {
         try tags.forEach { tag in
-            try merge(
-                tags: self.tags(
-                    descriptor: .tags(.isSameWith(tag))
-                )
+            let duplicates = try context.fetch(
+                .tags(.isSameWith(tag))
             )
+            try merge(tags: duplicates)
         }
     }
 
@@ -73,14 +67,7 @@ final class TagService {
     }
 
     func updateHasDuplicates() throws {
-        hasDuplicates = findDuplicates(
-            in: try tags()
-        ).isNotEmpty
-    }
-}
-
-private extension TagService {
-    func tags(descriptor: FetchDescriptor<Tag> = .tags(.all)) throws -> [Tag] {
-        try context.fetch(descriptor)
+        let allTags = try context.fetch(.tags(.all))
+        hasDuplicates = findDuplicates(in: allTags).isNotEmpty
     }
 }

--- a/Incomes/Sources/Tag/Model/TagType.swift
+++ b/Incomes/Sources/Tag/Model/TagType.swift
@@ -1,0 +1,30 @@
+//
+//  TagType.swift
+//  Incomes
+//
+//  Created by Hiromu Nakano on 2025/06/18.
+//  Copyright © 2025 Hiromu Nakano. All rights reserved.
+//
+
+import AppIntents
+import Foundation
+
+enum TagType: String {
+    case year = "aae8af65"
+    case yearMonth = "27c9be4b"
+    case content = "e2d390d9"
+    case category = "a7a130f4"
+}
+
+extension TagType: AppEnum {
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = .init(name: "Tag Type")
+
+    static var caseDisplayRepresentations: [Self: DisplayRepresentation] {
+        [
+            .year: .init(title: "Year"),
+            .yearMonth: .init(title: "Year/Month"),
+            .content: .init(title: "Content"),
+            .category: .init(title: "Category")
+        ]
+    }
+}

--- a/Incomes/Sources/Tag/View/TagListView.swift
+++ b/Incomes/Sources/Tag/View/TagListView.swift
@@ -24,9 +24,9 @@ struct TagListView {
     @State private var isDialogPresented = false
     @State private var willDeleteTags = [Tag]()
 
-    private let tagType: Tag.TagType
+    private let tagType: TagType
 
-    init(tagType: Tag.TagType, selection: Binding<IncomesPath?> = .constant(nil)) {
+    init(tagType: TagType, selection: Binding<IncomesPath?> = .constant(nil)) {
         self.tagType = tagType
         self._tags = .init(.tags(.typeIs(tagType)))
         self._path = selection

--- a/Incomes/Sources/Tag/View/TagNavigationView.swift
+++ b/Incomes/Sources/Tag/View/TagNavigationView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 struct TagNavigationView: View {
     @State private var path: IncomesPath?
 
-    private let tagType: Tag.TagType
+    private let tagType: TagType
 
-    init(tagType: Tag.TagType) {
+    init(tagType: TagType) {
         self.tagType = tagType
     }
 

--- a/IncomesTests/Default/GetAllTagsIntentTests.swift
+++ b/IncomesTests/Default/GetAllTagsIntentTests.swift
@@ -1,0 +1,18 @@
+@testable import Incomes
+import SwiftData
+import Testing
+
+struct GetAllTagsIntentTests {
+    let context: ModelContext
+
+    init() {
+        context = testContext
+    }
+
+    @Test func perform() throws {
+        _ = try Tag.create(context: context, name: "A", type: .year)
+        _ = try Tag.create(context: context, name: "B", type: .content)
+        let tags = try GetAllTagsIntent.perform(context)
+        #expect(tags.count == 2)
+    }
+}

--- a/IncomesTests/Default/GetTagByIDIntentTests.swift
+++ b/IncomesTests/Default/GetTagByIDIntentTests.swift
@@ -11,7 +11,7 @@ struct GetTagByIDIntentTests {
 
     @Test func perform() throws {
         let model = try Tag.create(context: context, name: "name", type: .content)
-        let id = try #require(model.id.base64Encoded())
+        let id = try model.id.base64Encoded()
         let tag = try #require(
             GetTagByIDIntent.perform(
                 (

--- a/IncomesTests/Default/GetTagByIDIntentTests.swift
+++ b/IncomesTests/Default/GetTagByIDIntentTests.swift
@@ -1,0 +1,26 @@
+@testable import Incomes
+import SwiftData
+import Testing
+
+struct GetTagByIDIntentTests {
+    let context: ModelContext
+
+    init() {
+        context = testContext
+    }
+
+    @Test func perform() throws {
+        let model = try Tag.create(context: context, name: "name", type: .content)
+        let id = try #require(model.id.base64Encoded())
+        let tag = try #require(
+            GetTagByIDIntent.perform(
+                (
+                    context: context,
+                    id: try .init(base64Encoded: id)
+                )
+            )
+        )
+        #expect(tag.name == "name")
+        #expect(tag.type == .content)
+    }
+}

--- a/IncomesTests/Default/GetTagByNameIntentTests.swift
+++ b/IncomesTests/Default/GetTagByNameIntentTests.swift
@@ -12,7 +12,7 @@ struct GetTagByNameIntentTests {
     @Test func perform() throws {
         _ = try Tag.create(context: context, name: "name", type: .year)
         let tag = try #require(
-            GetTagByNameIntent.perform(
+            try GetTagByNameIntent.perform(
                 (
                     context: context,
                     name: "name",

--- a/IncomesTests/Default/GetTagByNameIntentTests.swift
+++ b/IncomesTests/Default/GetTagByNameIntentTests.swift
@@ -1,0 +1,26 @@
+@testable import Incomes
+import SwiftData
+import Testing
+
+struct GetTagByNameIntentTests {
+    let context: ModelContext
+
+    init() {
+        context = testContext
+    }
+
+    @Test func perform() throws {
+        _ = try Tag.create(context: context, name: "name", type: .year)
+        let tag = try #require(
+            GetTagByNameIntent.perform(
+                (
+                    context: context,
+                    name: "name",
+                    type: .year
+                )
+            )
+        )
+        #expect(tag.name == "name")
+        #expect(tag.type == .year)
+    }
+}

--- a/IncomesTests/Default/TagServiceTests.swift
+++ b/IncomesTests/Default/TagServiceTests.swift
@@ -18,24 +18,10 @@ struct TagServiceTests {
         self.service = .init(context: context)
     }
 
-    // MARK: - Fetch
-
-    @Test func tag() throws {
-        #expect(try service.tag() == nil)
-
-        _ = try Tag.create(context: context, name: "nameA", type: .year)
-        _ = try Tag.create(context: context, name: "nameB", type: .year)
-
-        #expect(try context.fetchCount(.tags(.all)) == 2)
-
-        #expect(try service.tag()?.name == "nameA")
-        #expect(try service.tag()?.type == .year)
-    }
-
     // MARK: - Duplicates - merge
 
     @Test func mergeWhenTagsAreIdentical() throws {
-        #expect(try service.tag() == nil)
+        #expect(try GetAllTagsIntent.perform(context).isEmpty)
 
         let item1 = try Item.create(
             context: context,
@@ -89,7 +75,7 @@ struct TagServiceTests {
     }
 
     @Test func mergeWhenTagsAreDifferent() throws {
-        #expect(try service.tag() == nil)
+        #expect(try GetAllTagsIntent.perform(context).isEmpty)
 
         let item1 = try Item.create(
             context: context,
@@ -147,7 +133,7 @@ struct TagServiceTests {
     }
 
     @Test func mergeWhenTagsAreDuplicated() throws {
-        #expect(try service.tag() == nil)
+        #expect(try GetAllTagsIntent.perform(context).isEmpty)
 
         let item1 = try Item.createIgnoringDuplicates(
             context: context,


### PR DESCRIPTION
## Summary
- add intents for fetching tags
- replace `TagService` fetch calls with intents
- clean up TagService fetch helpers
- add new tests for Tag fetching intents

## Testing
- `swift test --parallel` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68518c60cae0832093d88c3e338f1229