### PR TITLE
Fix GetTagByIDIntent input

### DIFF
--- a/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
@@ -14,12 +14,10 @@ struct GetTagByIDIntent: AppIntent, IntentPerformer {
     typealias Output = TagEntity?
 
     static func perform(_ input: Input) throws -> Output {
-        guard let persistentID =
-            try? PersistentIdentifier(base64Encoded: input.id),
-            let tag = try input.context.fetchFirst(
-                .tags(.idIs(persistentID))
-            )
-        else {
+        let persistentID = try PersistentIdentifier(base64Encoded: input.id)
+        guard let tag = try input.context.fetchFirst(
+            .tags(.idIs(persistentID))
+        ) else {
             return nil
         }
         return TagEntity(tag)

--- a/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
@@ -11,23 +11,25 @@ struct GetTagByIDIntent: AppIntent, IntentPerformer {
     @Dependency private var modelContainer: ModelContainer
 
     typealias Input = (context: ModelContext, id: String)
-    typealias Output = Tag?
+    typealias Output = TagEntity?
 
     static func perform(_ input: Input) throws -> Output {
-        guard let persistentID = try? PersistentIdentifier(base64Encoded: input.id) else {
+        guard let persistentID =
+            try? PersistentIdentifier(base64Encoded: input.id),
+            let tag = try input.context.fetchFirst(
+                .tags(.idIs(persistentID))
+            )
+        else {
             return nil
         }
-        return try input.context.fetchFirst(
-            .tags(.idIs(persistentID))
-        )
+        return TagEntity(tag)
     }
 
     @MainActor
     func perform() throws -> some ReturnsValue<TagEntity?> {
-        guard let tag = try Self.perform(
+        guard let tagEntity = try Self.perform(
             (context: modelContainer.mainContext, id: id)
-        ),
-        let tagEntity = TagEntity(tag) else {
+        ) else {
             return .result(value: nil)
         }
         return .result(value: tagEntity)

--- a/Incomes/Sources/Tag/Models/TagEntityQuery.swift
+++ b/Incomes/Sources/Tag/Models/TagEntityQuery.swift
@@ -22,7 +22,6 @@ struct TagEntityQuery: EntityStringQuery {
                 )
             )
         }
-        .compactMap(TagEntity.init)
     }
 
     @MainActor

--- a/Incomes/Sources/Tag/Models/TagEntityQuery.swift
+++ b/Incomes/Sources/Tag/Models/TagEntityQuery.swift
@@ -18,7 +18,7 @@ struct TagEntityQuery: EntityStringQuery {
             try GetTagByIDIntent.perform(
                 (
                     context: modelContainer.mainContext,
-                    id: try .init(base64Encoded: id)
+                    id: id
                 )
             )
         }

--- a/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
@@ -13,7 +13,7 @@ struct GetTagByIDIntentTest {
         let model = try Tag.create(context: context, name: "name", type: .content)
         let id = try model.id.base64Encoded()
         let tagEntity = try #require(
-            GetTagByIDIntent.perform(
+            try GetTagByIDIntent.perform(
                 (
                     context: context,
                     id: id

--- a/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
@@ -16,7 +16,7 @@ struct GetTagByIDIntentTest {
             GetTagByIDIntent.perform(
                 (
                     context: context,
-                    id: try .init(base64Encoded: id)
+                    id: id
                 )
             )
         )

--- a/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
@@ -12,7 +12,7 @@ struct GetTagByIDIntentTest {
     @Test func perform() throws {
         let model = try Tag.create(context: context, name: "name", type: .content)
         let id = try model.id.base64Encoded()
-        let tag = try #require(
+        let tagEntity = try #require(
             GetTagByIDIntent.perform(
                 (
                     context: context,
@@ -20,7 +20,7 @@ struct GetTagByIDIntentTest {
                 )
             )
         )
-        #expect(tag.name == "name")
-        #expect(tag.type == .content)
+        #expect(tagEntity.name == "name")
+        #expect(tagEntity.type == .content)
     }
 }


### PR DESCRIPTION
## Summary
- match static input and parameter types for GetTagByIDIntent
- adjust TagEntityQuery to pass string IDs
- update GetTagByIDIntent tests

## Testing
- `swiftlint` *(fails: command not found)*
- `swift test` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68542498242883208dcda08a87abdbc1