### PR TITLE
Add OCR scanning for item form

### DIFF
--- a/Incomes/Sources/Item/Components/ItemFormOCRButton.swift
+++ b/Incomes/Sources/Item/Components/ItemFormOCRButton.swift
@@ -1,0 +1,74 @@
+import PhotosUI
+import SwiftUI
+import UIKit
+
+@available(iOS 26.0, *)
+struct ItemFormOCRButton: View {
+    @Binding var date: Date
+    @Binding var content: String
+    @Binding var income: String
+    @Binding var outgo: String
+    @Binding var category: String
+
+    @State private var selectedItem: PhotosPickerItem?
+    @StateObject private var scanner: ImageTextScanner = .init()
+
+    @State private var isProcessing = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        PhotosPicker(selection: $selectedItem, matching: .images) {
+            if isProcessing {
+                ProgressView()
+            } else {
+                Image(systemName: "doc.text.viewfinder")
+            }
+        }
+        .alert("Error", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        .onChange(of: selectedItem) { _ in
+            guard selectedItem != nil else { return }
+            Task {
+                await scanReceipt()
+            }
+        }
+    }
+
+    private func scanReceipt() async {
+        guard let item = selectedItem else { return }
+
+        isProcessing = true
+        defer { isProcessing = false; selectedItem = nil }
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self),
+                  let uiImage = UIImage(data: data) else { return }
+            try await scanner.scan(uiImage)
+            let text = scanner.recognizedText
+            let inference = try await InferItemFormIntent.perform(text)
+            if let newDate = inference.date.dateValueWithoutLocale(.yyyyMMdd) {
+                date = newDate
+            }
+            content = inference.content
+            income = inference.income.description
+            outgo = inference.outgo.description
+            category = inference.category
+        } catch {
+            errorMessage = error.localizedDescription
+            assertionFailure(error.localizedDescription)
+        }
+    }
+}
+
+@available(iOS 26.0, *)
+#Preview {
+    ItemFormOCRButton(
+        date: .constant(.now),
+        content: .constant(.empty),
+        income: .constant(.empty),
+        outgo: .constant(.empty),
+        category: .constant(.empty)
+    )
+}

--- a/Incomes/Sources/Item/Models/ImageTextScanner.swift
+++ b/Incomes/Sources/Item/Models/ImageTextScanner.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import UIKit
+import VisionKit
+
+@MainActor
+final class ImageTextScanner: ObservableObject {
+    @Published var recognizedText = String()
+    @Published var isScanning = false
+
+    func scan(_ image: UIImage) async throws {
+        isScanning = true
+        defer { isScanning = false }
+
+        let analyzer: ImageAnalyzer = .init()
+        let configuration: ImageAnalyzer.Configuration = .init([.text])
+        let analysis = try await analyzer.analyze(image, configuration: configuration)
+        recognizedText = analysis.transcript
+    }
+}

--- a/Incomes/Sources/Item/Views/ItemFormView.swift
+++ b/Incomes/Sources/Item/Views/ItemFormView.swift
@@ -143,13 +143,22 @@ struct ItemFormView: View {
             }
             ToolbarItem(placement: .bottomBar) {
                 if #available(iOS 26.0, *) {
-                    ItemFormVoiceButton(
-                        date: $date,
-                        content: $content,
-                        income: $income,
-                        outgo: $outgo,
-                        category: $category
-                    )
+                    HStack {
+                        ItemFormOCRButton(
+                            date: $date,
+                            content: $content,
+                            income: $income,
+                            outgo: $outgo,
+                            category: $category
+                        )
+                        ItemFormVoiceButton(
+                            date: $date,
+                            content: $content,
+                            income: $income,
+                            outgo: $outgo,
+                            category: $category
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add `ImageTextScanner` to extract text from images
- introduce `ItemFormOCRButton` that uses the scanner and feeds text to `InferItemFormIntent`
- show the OCR button next to the existing voice button in `ItemFormView`

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ab629eb08320992408c183cc7c1d