### PR TITLE
Add OCR receipt scanning

### DIFF
--- a/Incomes/Sources/Item/Components/ItemFormOCRButton.swift
+++ b/Incomes/Sources/Item/Components/ItemFormOCRButton.swift
@@ -1,0 +1,81 @@
+import AppIntents
+import PhotosUI
+import SwiftUI
+
+@available(iOS 26.0, *)
+struct ItemFormOCRButton: View {
+    @Binding var date: Date
+    @Binding var content: String
+    @Binding var income: String
+    @Binding var outgo: String
+    @Binding var category: String
+
+    @State private var selectedItem: PhotosPickerItem?
+    @StateObject private var scanner = OCRScanner()
+
+    @State private var isProcessing = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        PhotosPicker(selection: $selectedItem, matching: .images) {
+            if isProcessing {
+                ProgressView()
+            } else {
+                Image(systemName: "text.viewfinder")
+            }
+        }
+        .alert("Error", isPresented: Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        .onChange(of: selectedItem) { _ in
+            guard let selectedItem else { return }
+            Task {
+                await process(item: selectedItem)
+            }
+        }
+    }
+
+    private func process(item: PhotosPickerItem) async {
+        isProcessing = true
+        defer { isProcessing = false }
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self),
+                  let uiImage = UIImage(data: data) else {
+                return
+            }
+            let text = try await scanner.scan(image: uiImage)
+            await updateForm(with: text)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func updateForm(with text: String) async {
+        do {
+            let inference = try await InferItemFormIntent.perform(text)
+            if let newDate = inference.date.dateValueWithoutLocale(.yyyyMMdd) {
+                date = newDate
+            }
+            content = inference.content
+            income = inference.income.description
+            outgo = inference.outgo.description
+            category = inference.category
+        } catch {
+            errorMessage = error.localizedDescription
+            assertionFailure(error.localizedDescription)
+        }
+    }
+}
+
+@available(iOS 26.0, *)
+#Preview {
+    ItemFormOCRButton(
+        date: .constant(.now),
+        content: .constant(.empty),
+        income: .constant(.empty),
+        outgo: .constant(.empty),
+        category: .constant(.empty)
+    )
+}

--- a/Incomes/Sources/Item/Models/OCRScanner.swift
+++ b/Incomes/Sources/Item/Models/OCRScanner.swift
@@ -1,0 +1,18 @@
+import Vision
+import UIKit
+
+@MainActor
+final class OCRScanner {
+    func scan(image: UIImage) async throws -> String {
+        guard let cgImage = image.cgImage else { return String() }
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.recognitionLanguages = [Locale.current.language.languageCode?.identifier ?? "en"]
+        let handler = VNImageRequestHandler(cgImage: cgImage)
+        try handler.perform([request])
+        let results = request.results ?? []
+        return results
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: "\n")
+    }
+}

--- a/Incomes/Sources/Item/Views/ItemFormView.swift
+++ b/Incomes/Sources/Item/Views/ItemFormView.swift
@@ -143,13 +143,22 @@ struct ItemFormView: View {
             }
             ToolbarItem(placement: .bottomBar) {
                 if #available(iOS 26.0, *) {
-                    ItemFormVoiceButton(
-                        date: $date,
-                        content: $content,
-                        income: $income,
-                        outgo: $outgo,
-                        category: $category
-                    )
+                    HStack {
+                        ItemFormVoiceButton(
+                            date: $date,
+                            content: $content,
+                            income: $income,
+                            outgo: $outgo,
+                            category: $category
+                        )
+                        ItemFormOCRButton(
+                            date: $date,
+                            content: $content,
+                            income: $income,
+                            outgo: $outgo,
+                            category: $category
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add OCRScanner utility to recognize text from images
- add ItemFormOCRButton for selecting receipts and filling forms
- show OCR button with voice button in ItemFormView

## Testing
- `swiftlint` *(fails: cannot execute binary file)*
- `markdownlint **/*.md` *(fails: line-length errors in existing docs)*

------
https://chatgpt.com/codex/tasks/task_e_6854ae13d3b88320952ec2101f5c3c59