### PR TITLE
Fix trailing closure formatting

### DIFF
--- a/Incomes/Sources/Home/Components/HomeTabSectionLink.swift
+++ b/Incomes/Sources/Home/Components/HomeTabSectionLink.swift
@@ -21,7 +21,11 @@ extension HomeTabSectionLink: View {
                 HStack {
                     Text("Total Income")
                     Spacer()
-                    Text(yearTag.items.orEmpty.reduce(.zero) { $0 + $1.income }.asCurrency)
+                    Text(
+                        yearTag.items.orEmpty.reduce(.zero) {
+                            $0 + $1.income
+                        }.asCurrency
+                    )
                         .foregroundStyle(.secondary)
                     Image(systemName: "chevron.up")
                         .foregroundStyle(.tint)
@@ -30,7 +34,11 @@ extension HomeTabSectionLink: View {
                 HStack {
                     Text("Total Outgo")
                     Spacer()
-                    Text(yearTag.items.orEmpty.reduce(.zero) { $0 + $1.outgo }.asMinusCurrency)
+                    Text(
+                        yearTag.items.orEmpty.reduce(.zero) {
+                            $0 + $1.outgo
+                        }.asMinusCurrency
+                    )
                         .foregroundStyle(.secondary)
                     Image(systemName: "chevron.down")
                         .foregroundStyle(.red)
@@ -46,7 +54,11 @@ extension HomeTabSectionLink: View {
     IncomesPreview { preview in
         List {
             HomeTabSectionLink()
-                .environment(preview.tags.first { $0.type == .year })
+                .environment(
+                    preview.tags.first {
+                        $0.type == .year
+                    }
+                )
         }
     }
 }

--- a/Incomes/Sources/Home/Components/HomeYearSection.swift
+++ b/Incomes/Sources/Home/Components/HomeYearSection.swift
@@ -36,7 +36,9 @@ struct HomeYearSection: View {
             }.onDelete {
                 Haptic.warning.impact()
                 isDialogPresented = true
-                willDeleteItems = $0.flatMap { yearMonthTags[$0].items ?? [] }
+                willDeleteItems = $0.flatMap {
+                    yearMonthTags[$0].items ?? []
+                }
             }
         }
         .confirmationDialog(

--- a/Incomes/Sources/Item/Components/Chart/CategoryChartSection.swift
+++ b/Incomes/Sources/Item/Components/Chart/CategoryChartSection.swift
@@ -29,7 +29,9 @@ struct CategoryChartSection: View {
                 }.map { displayName, items in
                     (
                         title: displayName,
-                        value: items.reduce(.zero) { $0 + $1.income }
+                        value: items.reduce(.zero) {
+                            $0 + $1.income
+                        }
                     )
                 }.sorted {
                     $0.value > $1.value
@@ -61,7 +63,9 @@ struct CategoryChartSection: View {
                 }.map { displayName, items in
                     (
                         title: displayName,
-                        value: items.reduce(.zero) { $0 + $1.outgo }
+                        value: items.reduce(.zero) {
+                            $0 + $1.outgo
+                        }
                     )
                 }.sorted {
                     $0.value > $1.value

--- a/Incomes/Sources/Item/Components/ItemListSection.swift
+++ b/Incomes/Sources/Item/Components/ItemListSection.swift
@@ -33,7 +33,9 @@ struct ItemListSection: View {
             }
             .onDelete {
                 Haptic.warning.impact()
-                willDeleteItems = $0.map { items[$0] }
+                willDeleteItems = $0.map {
+                    items[$0]
+                }
                 isDialogPresented = true
             }
         } header: {

--- a/Incomes/Sources/Item/Components/TagItemListSection.swift
+++ b/Incomes/Sources/Item/Components/TagItemListSection.swift
@@ -33,7 +33,9 @@ extension TagItemListSection: View {
             }
             .onDelete {
                 Haptic.warning.impact()
-                willDeleteItems = $0.map { items[$0] }
+                willDeleteItems = $0.map {
+                    items[$0]
+                }
                 isDialogPresented = true
             }
         } header: {
@@ -78,7 +80,11 @@ private extension TagItemListSection {
     IncomesPreview { preview in
         List {
             TagItemListSection(yearString: Date.now.stringValueWithoutLocale(.yyyy))
-                .environment(preview.tags.first { $0.type == .category })
+                .environment(
+                    preview.tags.first {
+                        $0.type == .category
+                    }
+                )
         }
     }
 }

--- a/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
@@ -13,7 +13,9 @@ struct DeleteAllItemsIntent: AppIntent, IntentPerformer {
     static func perform(_ input: Input) throws -> Output {
         let context = input
         let items = try context.fetch(FetchDescriptor<Item>())
-        items.forEach { $0.delete() }
+        items.forEach {
+            $0.delete()
+        }
         let calculator = BalanceCalculator()
         try calculator.calculate(in: context, for: items)
     }

--- a/Incomes/Sources/Item/Models/ItemEntityQuery.swift
+++ b/Incomes/Sources/Item/Models/ItemEntityQuery.swift
@@ -15,7 +15,13 @@ struct ItemEntityQuery: EntityStringQuery {
     @MainActor
     func entities(for identifiers: [ItemEntity.ID]) throws -> [ItemEntity] {
         try modelContainer.mainContext.fetch(
-            .items(.idsAre(identifiers.map { try .init(base64Encoded: $0) }))
+            .items(
+                .idsAre(
+                    identifiers.map {
+                        try .init(base64Encoded: $0)
+                    }
+                )
+            )
         )
         .compactMap(ItemEntity.init)
     }

--- a/Incomes/Sources/Item/Models/SpeechTranscriber.swift
+++ b/Incomes/Sources/Item/Models/SpeechTranscriber.swift
@@ -13,11 +13,15 @@ final class SpeechTranscriber: ObservableObject {
     private let audioEngine = AVAudioEngine()
 
     func startTranscribing() throws {
-        guard !isTranscribing else { return }
+        guard !isTranscribing else {
+            return
+        }
         try AVAudioSession.sharedInstance().setCategory(.record, mode: .measurement)
         try AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
         request = .init()
-        guard let request else { return }
+        guard let request else {
+            return
+        }
         let inputNode = audioEngine.inputNode
         inputNode.removeTap(onBus: .zero)
         inputNode.installTap(onBus: .zero, bufferSize: 1_024, format: inputNode.outputFormat(forBus: .zero)) { buffer, _ in
@@ -26,7 +30,9 @@ final class SpeechTranscriber: ObservableObject {
         audioEngine.prepare()
         try audioEngine.start()
         task = recognizer?.recognitionTask(with: request) { [weak self] result, error in
-            guard let self else { return }
+            guard let self else {
+                return
+            }
             if let result {
                 transcript = result.bestTranscription.formattedString
             }
@@ -38,7 +44,9 @@ final class SpeechTranscriber: ObservableObject {
     }
 
     func stopTranscribing() {
-        guard isTranscribing else { return }
+        guard isTranscribing else {
+            return
+        }
         audioEngine.stop()
         request?.endAudio()
         task?.cancel()

--- a/Incomes/Sources/Item/Views/ItemListView.swift
+++ b/Incomes/Sources/Item/Views/ItemListView.swift
@@ -79,7 +79,11 @@ private extension ItemListView {
     IncomesPreview { preview in
         NavigationStack {
             ItemListView()
-                .environment(preview.tags.first { $0.type == .year })
+                .environment(
+                    preview.tags.first {
+                        $0.type == .year
+                    }
+                )
         }
     }
 }
@@ -88,7 +92,11 @@ private extension ItemListView {
     IncomesPreview { preview in
         NavigationStack {
             ItemListView()
-                .environment(preview.tags.first { $0.type == .yearMonth })
+                .environment(
+                    preview.tags.first {
+                        $0.type == .yearMonth
+                    }
+                )
         }
     }
 }
@@ -97,7 +105,11 @@ private extension ItemListView {
     IncomesPreview { preview in
         NavigationStack {
             ItemListView()
-                .environment(preview.tags.first { $0.type == .content })
+                .environment(
+                    preview.tags.first {
+                        $0.type == .content
+                    }
+                )
         }
     }
 }
@@ -106,7 +118,11 @@ private extension ItemListView {
     IncomesPreview { preview in
         NavigationStack {
             ItemListView()
-                .environment(preview.tags.first { $0.type == .category })
+                .environment(
+                    preview.tags.first {
+                        $0.type == .category
+                    }
+                )
         }
     }
 }

--- a/Incomes/Sources/Item/Views/YearChartsView.swift
+++ b/Incomes/Sources/Item/Views/YearChartsView.swift
@@ -49,7 +49,11 @@ struct YearChartsView: View {
     IncomesPreview { preview in
         NavigationStack {
             YearChartsView()
-                .environment(preview.tags.first { $0.type == .year })
+                .environment(
+                    preview.tags.first {
+                        $0.type == .year
+                    }
+                )
         }
     }
 }

--- a/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
@@ -13,7 +13,9 @@ struct DeleteAllTagsIntent: AppIntent, IntentPerformer {
     static func perform(_ input: Input) throws -> Output {
         let context = input
         let tags = try context.fetch(FetchDescriptor<Tag>())
-        tags.forEach { $0.delete() }
+        tags.forEach {
+            $0.delete()
+        }
     }
 
     @MainActor

--- a/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
@@ -22,7 +22,9 @@ struct MergeDuplicateTagsIntent: AppIntent, IntentPerformer {
         guard let parent = models.first else {
             return
         }
-        let children = models.filter { $0.id != parent.id }
+        let children = models.filter {
+            $0.id != parent.id
+        }
         for item in children.flatMap({ $0.items ?? [] }) {
             var tags = item.tags ?? []
             tags.append(parent)

--- a/Incomes/Sources/Tag/Models/TagEntityQuery.swift
+++ b/Incomes/Sources/Tag/Models/TagEntityQuery.swift
@@ -58,7 +58,9 @@ struct TagEntityQuery: EntityStringQuery {
             .category
         ]
         .compactMap { type in
-            tags.first { $0.type == type }
+            tags.first {
+                $0.type == type
+            }
         }
         .compactMap(TagEntity.init)
     }

--- a/Incomes/Sources/Tag/Views/DuplicateTagListView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagListView.swift
@@ -80,7 +80,9 @@ struct DuplicateTagListView: View {
                 let id = try PersistentIdentifier(base64Encoded: entity.id)
                 return try context.fetchFirst(.tags(.idIs(id)))
             }
-            .sorted { $0.displayName < $1.displayName }
+            .sorted {
+                $0.displayName < $1.displayName
+            }
         } catch {
             assertionFailure(error.localizedDescription)
             duplicates = []

--- a/Incomes/Sources/Tag/Views/TagListView.swift
+++ b/Incomes/Sources/Tag/Views/TagListView.swift
@@ -52,7 +52,9 @@ struct TagListView: View {
             .onDelete { indices in
                 Haptic.warning.impact()
                 isDialogPresented = true
-                willDeleteTags = indices.map { tags[$0] }
+                willDeleteTags = indices.map {
+                    tags[$0]
+                }
             }
         }
         .searchable(text: $searchText)
@@ -76,7 +78,9 @@ struct TagListView: View {
             Button(role: .destructive) {
                 do {
                     let tags = willDeleteTags
-                    let items = tags.flatMap { $0.items ?? .empty }
+                    let items = tags.flatMap {
+                        $0.items ?? .empty
+                    }
                     try tags
                         .compactMap(TagEntity.init)
                         .forEach {

--- a/IncomesTests/Default/Intent/MergeDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/MergeDuplicateTagsIntentTest.swift
@@ -37,9 +37,15 @@ struct MergeDuplicateTagsIntentTest {
             category: "",
             repeatID: .init()
         )
-        let tag1 = item1.tags!.first { $0.type == .content }!
-        let tag2 = item2.tags!.first { $0.type == .content }!
-        let tag3 = item3.tags!.first { $0.type == .content }!
+        let tag1 = item1.tags!.first {
+            $0.type == .content
+        }!
+        let tag2 = item2.tags!.first {
+            $0.type == .content
+        }!
+        let tag3 = item3.tags!.first {
+            $0.type == .content
+        }!
 
         try MergeDuplicateTagsIntent.perform(
             (

--- a/IncomesTests/TimeZone/ItemPredicateTest.swift
+++ b/IncomesTests/TimeZone/ItemPredicateTest.swift
@@ -65,10 +65,26 @@ struct ItemPredicateTest {
         let items = try context.fetch(.items(predicate))
 
         try #require(items.count == 1)
-        #expect(items[0].tags?.first { $0.type == .year }?.name == "2024")
-        #expect(items[0].tags?.first { $0.type == .yearMonth }?.name == "202401")
-        #expect(items[0].tags?.first { $0.type == .content }?.name == "Content")
-        #expect(items[0].tags?.first { $0.type == .category }?.name == "Category")
+        #expect(
+            items[0].tags?.first {
+                $0.type == .year
+            }?.name == "2024"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .yearMonth
+            }?.name == "202401"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .content
+            }?.name == "Content"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .category
+            }?.name == "Category"
+        )
     }
 
     @Test("returns items with matching yearMonth tag", arguments: timeZones)
@@ -83,10 +99,26 @@ struct ItemPredicateTest {
         let items = try context.fetch(.items(predicate))
 
         try #require(items.count == 1)
-        #expect(items[0].tags?.first { $0.type == .year }?.name == "2024")
-        #expect(items[0].tags?.first { $0.type == .yearMonth }?.name == "202401")
-        #expect(items[0].tags?.first { $0.type == .content }?.name == "Content")
-        #expect(items[0].tags?.first { $0.type == .category }?.name == "Category")
+        #expect(
+            items[0].tags?.first {
+                $0.type == .year
+            }?.name == "2024"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .yearMonth
+            }?.name == "202401"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .content
+            }?.name == "Content"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .category
+            }?.name == "Category"
+        )
     }
 
     @Test("returns items with matching content and year for tagAndYear", arguments: timeZones)
@@ -101,10 +133,26 @@ struct ItemPredicateTest {
         let items = try context.fetch(.items(predicate))
 
         try #require(items.count == 1)
-        #expect(items[0].tags?.first { $0.type == .year }?.name == "2024")
-        #expect(items[0].tags?.first { $0.type == .yearMonth }?.name == "202401")
-        #expect(items[0].tags?.first { $0.type == .content }?.name == "Content")
-        #expect(items[0].tags?.first { $0.type == .category }?.name == "Category")
+        #expect(
+            items[0].tags?.first {
+                $0.type == .year
+            }?.name == "2024"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .yearMonth
+            }?.name == "202401"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .content
+            }?.name == "Content"
+        )
+        #expect(
+            items[0].tags?.first {
+                $0.type == .category
+            }?.name == "Category"
+        )
     }
 
     // MARK: - Date
@@ -753,7 +801,9 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-01-01T00:00:00Z"), content: "RepeatOne", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        let repeatOneItem = try context.fetch(.items(.all)).first { $0.content == "RepeatOne" }!
+        let repeatOneItem = try context.fetch(.items(.all)).first {
+            $0.content == "RepeatOne"
+        }!
         let repeatID = repeatOneItem.repeatID
         _ = try CreateItemIntent.perform((context: context, date: shiftedDate("2024-02-01T00:00:00Z"), content: "NonRepeat", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 


### PR DESCRIPTION
## Summary
- fix single-line guard statements in `SpeechTranscriber`
- break trailing closures across the project to obey multiline style guidelines
- update tests to match new closure formatting

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint --fix --format --strict` *(fails: SourceKitten missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854b886ae5c83209c16fb90cffc4598