### PR TITLE
Fix AppIntent member order

### DIFF
--- a/Incomes/Sources/Item/Intents/Create/CreateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Create/CreateItemIntent.swift
@@ -12,7 +12,8 @@ import SwiftUI
 import SwiftUtilities
 
 struct CreateItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Create Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date, content: String, income: Decimal, outgo: Decimal, category: String, repeatCount: Int)
+    typealias Output = ItemEntity
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
@@ -29,8 +30,7 @@ struct CreateItemIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date, content: String, income: Decimal, outgo: Decimal, category: String, repeatCount: Int)
-    typealias Output = ItemEntity
+    static let title: LocalizedStringResource = .init("Create Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, date, content, income, outgo, category, repeatCount) = input

--- a/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
@@ -3,12 +3,12 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteAllItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Delete All Items", table: "AppIntents")
+    typealias Input = ModelContext
+    typealias Output = Void
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Delete All Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let context = input

--- a/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Delete Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, item: ItemEntity)
+    typealias Output = Void
 
     @Parameter(title: "Item")
     private var item: ItemEntity
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, item: ItemEntity)
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Delete Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entity) = input

--- a/Incomes/Sources/Item/Intents/Get/GetAllItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetAllItemsCountIntent.swift
@@ -3,12 +3,12 @@ import SwiftData
 import SwiftUtilities
 
 struct GetAllItemsCountIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get All Items Count", table: "AppIntents")
+    typealias Input = ModelContext
+    typealias Output = Int
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = Int
+    static let title: LocalizedStringResource = .init("Get All Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try input.fetchCount(.items(.all))

--- a/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
@@ -11,14 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]
+
+    static let title: LocalizedStringResource = .init("Get Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try input.context.fetch(

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemContentIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemContentIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetNextItemContentIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Next Item Content", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = String?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = String?
+    static let title: LocalizedStringResource = .init("Get Next Item Content", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemDateIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemDateIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetNextItemDateIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Next Item Date", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = Date?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = Date?
+    static let title: LocalizedStringResource = .init("Get Next Item Date", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemIntent.swift
@@ -11,14 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetNextItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Next Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = ItemEntity?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
+
+    static let title: LocalizedStringResource = .init("Get Next Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsAfter(input.date), order: .forward)

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemProfitIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemProfitIntent.swift
@@ -12,15 +12,15 @@ import SwiftUI
 import SwiftUtilities
 
 struct GetNextItemProfitIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Next Item Profit", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = IntentCurrencyAmount?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = IntentCurrencyAmount?
+    static let title: LocalizedStringResource = .init("Get Next Item Profit", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
@@ -11,14 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetNextItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Next Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+
+    static let title: LocalizedStringResource = .init("Get Next Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsAfter(input.date), order: .forward)

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemContentIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemContentIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetPreviousItemContentIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Previous Item Content", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = String?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = String?
+    static let title: LocalizedStringResource = .init("Get Previous Item Content", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetPreviousItemIntent.perform(input)?.content

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemDateIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemDateIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetPreviousItemDateIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Previous Item Date", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = Date?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = Date?
+    static let title: LocalizedStringResource = .init("Get Previous Item Date", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         guard let item = try GetPreviousItemIntent.perform(input) else {

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemIntent.swift
@@ -11,14 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetPreviousItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Previous Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = ItemEntity?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
+
+    static let title: LocalizedStringResource = .init("Get Previous Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsBefore(input.date))

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemProfitIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemProfitIntent.swift
@@ -12,15 +12,15 @@ import SwiftUI
 import SwiftUtilities
 
 struct GetPreviousItemProfitIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Previous Item Profit", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = IntentCurrencyAmount?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = IntentCurrencyAmount?
+    static let title: LocalizedStringResource = .init("Get Previous Item Profit", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         guard let item = try GetPreviousItemIntent.perform(input) else {

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemsIntent.swift
@@ -11,14 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetPreviousItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Previous Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+
+    static let title: LocalizedStringResource = .init("Get Previous Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsBefore(input.date))

--- a/Incomes/Sources/Item/Intents/Get/GetRepeatItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetRepeatItemsCountIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetRepeatItemsCountIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Repeat Items Count", table: "AppIntents")
+    typealias Input = (context: ModelContext, repeatID: UUID)
+    typealias Output = Int
 
     @Parameter(title: "Repeat ID")
     private var repeatID: String
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, repeatID: UUID)
-    typealias Output = Int
+    static let title: LocalizedStringResource = .init("Get Repeat Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try input.context.fetchCount(.items(.repeatIDIs(input.repeatID)))

--- a/Incomes/Sources/Item/Intents/Get/GetYearItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetYearItemsCountIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetYearItemsCountIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Year Items Count", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = Int
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = Int
+    static let title: LocalizedStringResource = .init("Get Year Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try input.context.fetchCount(.items(.dateIsSameYearAs(input.date)))

--- a/Incomes/Sources/Item/Intents/Show/CreateAndShowItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/CreateAndShowItemIntent.swift
@@ -11,7 +11,8 @@ import SwiftData
 import SwiftUtilities
 
 struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Create and Show Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date, content: String, income: Double, outgo: Double, category: String, repeatCount: Int)
+    typealias Output = ItemEntity
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
@@ -28,8 +29,7 @@ struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date, content: String, income: Double, outgo: Double, category: String, repeatCount: Int)
-    typealias Output = ItemEntity
+    static let title: LocalizedStringResource = .init("Create and Show Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, date, content, income, outgo, category, repeatCount) = input

--- a/Incomes/Sources/Item/Intents/Show/ShowChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowChartsIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowChartsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Charts", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    static let title: LocalizedStringResource = .init("Show Charts", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let items = try input.context.fetch(

--- a/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    static let title: LocalizedStringResource = .init("Show Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let items = try input.context.fetch(

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowNextItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Next Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = ItemEntity?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
+    static let title: LocalizedStringResource = .init("Show Next Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetNextItemIntent.perform((context: input.context, date: input.date))

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowNextItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Next Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    static let title: LocalizedStringResource = .init("Show Next Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetNextItemsIntent.perform(input)

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowPreviousItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Previous Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = ItemEntity?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
+    static let title: LocalizedStringResource = .init("Show Previous Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetPreviousItemIntent.perform(input)

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
@@ -11,15 +11,15 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowPreviousItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Previous Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    static let title: LocalizedStringResource = .init("Show Previous Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetPreviousItemsIntent.perform(input)

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemIntent.swift
@@ -11,12 +11,12 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowRecentItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Recent Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = ItemEntity?
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
+    static let title: LocalizedStringResource = .init("Show Recent Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetPreviousItemIntent.perform(input)

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
@@ -11,12 +11,12 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowRecentItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Recent Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    static let title: LocalizedStringResource = .init("Show Recent Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetPreviousItemsIntent.perform(input)

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
@@ -11,12 +11,12 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowThisMonthChartsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show This Month's Charts", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    static let title: LocalizedStringResource = .init("Show This Month's Charts", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try ShowChartsIntent.perform(input)

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
@@ -11,12 +11,12 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowThisMonthItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show This Month's Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    static let title: LocalizedStringResource = .init("Show This Month's Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try ShowItemsIntent.perform(input)

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemIntent.swift
@@ -11,12 +11,12 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowUpcomingItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Upcoming Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = ItemEntity?
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
+    static let title: LocalizedStringResource = .init("Show Upcoming Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetNextItemIntent.perform((context: input.context, date: input.date))

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
@@ -11,12 +11,12 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowUpcomingItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Show Upcoming Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = [Item]?
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    static let title: LocalizedStringResource = .init("Show Upcoming Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try GetNextItemsIntent.perform(input)

--- a/Incomes/Sources/Item/Intents/Update/RecalculateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/RecalculateItemIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct RecalculateItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Recalculate Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, date: Date)
+    typealias Output = Void
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Recalculate Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let calculator = BalanceCalculator()

--- a/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
@@ -4,7 +4,8 @@ import SwiftUI
 import SwiftUtilities
 
 struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Update All Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
+    typealias Output = Void
 
     @Parameter(title: "Item")
     private var item: ItemEntity
@@ -21,8 +22,7 @@ struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Update All Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entity, date, content, income, outgo, category) = input

--- a/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
@@ -4,7 +4,8 @@ import SwiftUI
 import SwiftUtilities
 
 struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Update Future Items", table: "AppIntents")
+    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
+    typealias Output = Void
 
     @Parameter(title: "Item")
     private var item: ItemEntity
@@ -21,8 +22,7 @@ struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Update Future Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entity, date, content, income, outgo, category) = input

--- a/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
@@ -4,7 +4,8 @@ import SwiftUI
 import SwiftUtilities
 
 struct UpdateItemIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Update Item", table: "AppIntents")
+    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
+    typealias Output = Void
 
     @Parameter(title: "Item")
     private var item: ItemEntity
@@ -21,8 +22,7 @@ struct UpdateItemIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Update Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entity, date, content, income, outgo, category) = input

--- a/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
@@ -4,7 +4,17 @@ import SwiftUI
 import SwiftUtilities
 
 struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Update Repeating Items", table: "AppIntents")
+    typealias Input = (
+        context: ModelContext,
+        item: ItemEntity,
+        date: Date,
+        content: String,
+        income: Decimal,
+        outgo: Decimal,
+        category: String,
+        descriptor: FetchDescriptor<Item>
+    )
+    typealias Output = Void
 
     @Parameter(title: "Item")
     private var item: ItemEntity
@@ -21,17 +31,7 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (
-        context: ModelContext,
-        item: ItemEntity,
-        date: Date,
-        content: String,
-        income: Decimal,
-        outgo: Decimal,
-        category: String,
-        descriptor: FetchDescriptor<Item>
-    )
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Update Repeating Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entity, date, content, income, outgo, category, descriptor) = input

--- a/Incomes/Sources/Main/Intents/OpenIncomesIntent.swift
+++ b/Incomes/Sources/Main/Intents/OpenIncomesIntent.swift
@@ -10,11 +10,11 @@ import AppIntents
 import SwiftUtilities
 
 struct OpenIncomesIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Open Incomes", table: "AppIntents")
-    static let openAppWhenRun = true
-
     typealias Input = Void
     typealias Output = Void
+
+    static let title: LocalizedStringResource = .init("Open Incomes", table: "AppIntents")
+    static let openAppWhenRun = true
 
     static func perform(_: Input) throws -> Output {}
 

--- a/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
@@ -3,12 +3,12 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteAllTagsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Delete All Tags", table: "AppIntents")
+    typealias Input = ModelContext
+    typealias Output = Void
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Delete All Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let context = input

--- a/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteTagIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Delete Tag", table: "AppIntents")
+    typealias Input = (context: ModelContext, tag: TagEntity)
+    typealias Output = Void
 
     @Parameter(title: "Tag")
     private var tag: TagEntity
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, tag: TagEntity)
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Delete Tag", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entity) = input

--- a/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct FindDuplicateTagsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Find Duplicate Tags", table: "AppIntents")
+    typealias Input = (context: ModelContext, tags: [TagEntity])
+    typealias Output = [TagEntity]
 
     @Parameter(title: "Tags")
     private var tags: [TagEntity]
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, tags: [TagEntity])
-    typealias Output = [TagEntity]
+    static let title: LocalizedStringResource = .init("Find Duplicate Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entities) = input

--- a/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
@@ -3,12 +3,12 @@ import SwiftData
 import SwiftUtilities
 
 struct GetAllTagsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get All Tags", table: "AppIntents")
+    typealias Input = ModelContext
+    typealias Output = [Tag]
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = [Tag]
+    static let title: LocalizedStringResource = .init("Get All Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try input.fetch(.tags(.all))

--- a/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
@@ -3,12 +3,12 @@ import SwiftData
 import SwiftUtilities
 
 struct GetHasDuplicateTagsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Has Duplicate Tags", table: "AppIntents")
+    typealias Input = ModelContext
+    typealias Output = Bool
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = ModelContext
-    typealias Output = Bool
+    static let title: LocalizedStringResource = .init("Get Has Duplicate Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let context = input

--- a/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct GetTagByIDIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Tag By ID", table: "AppIntents")
+    typealias Input = (context: ModelContext, id: String)
+    typealias Output = TagEntity?
 
     @Parameter(title: "Tag ID")
     var id: String
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, id: String)
-    typealias Output = TagEntity?
+    static let title: LocalizedStringResource = .init("Get Tag By ID", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let persistentID = try PersistentIdentifier(base64Encoded: input.id)

--- a/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
@@ -3,7 +3,8 @@ import SwiftData
 import SwiftUtilities
 
 struct GetTagByNameIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Get Tag By Name", table: "AppIntents")
+    typealias Input = (context: ModelContext, name: String, type: TagType)
+    typealias Output = Tag?
 
     @Parameter(title: "Name")
     private var name: String
@@ -12,8 +13,7 @@ struct GetTagByNameIntent: AppIntent, IntentPerformer {
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, name: String, type: TagType)
-    typealias Output = Tag?
+    static let title: LocalizedStringResource = .init("Get Tag By Name", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         try input.context.fetchFirst(

--- a/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct MergeDuplicateTagsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Merge Duplicate Tags", table: "AppIntents")
+    typealias Input = (context: ModelContext, tags: [TagEntity])
+    typealias Output = Void
 
     @Parameter(title: "Tags")
     private var tags: [TagEntity]
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, tags: [TagEntity])
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Merge Duplicate Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entities) = input

--- a/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
@@ -3,15 +3,15 @@ import SwiftData
 import SwiftUtilities
 
 struct ResolveDuplicateTagsIntent: AppIntent, IntentPerformer {
-    static let title: LocalizedStringResource = .init("Resolve Duplicate Tags", table: "AppIntents")
+    typealias Input = (context: ModelContext, tags: [TagEntity])
+    typealias Output = Void
 
     @Parameter(title: "Tags")
     private var tags: [TagEntity]
 
     @Dependency private var modelContainer: ModelContainer
 
-    typealias Input = (context: ModelContext, tags: [TagEntity])
-    typealias Output = Void
+    static let title: LocalizedStringResource = .init("Resolve Duplicate Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
         let (context, entities) = input


### PR DESCRIPTION
## Summary
- reorder properties and methods in `UpdateRepeatingItemsIntent`
- remove trailing blank lines from all intents

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}')` *(fails: HTTP 403 fetching SwiftLint)*

------
https://chatgpt.com/codex/tasks/task_e_68550cc669ec83209f06ec4b3a6cd652