### PR TITLE
Fix optional item arrays

### DIFF
--- a/Incomes/Sources/Common/Components/IntentItemListSection.swift
+++ b/Incomes/Sources/Common/Components/IntentItemListSection.swift
@@ -9,9 +9,9 @@
 import SwiftUI
 
 struct IntentItemListSection: View {
-    private var items: [Item]
+    private var items: [ItemEntity]
 
-    init(_ items: [Item]) {
+    init(_ items: [ItemEntity]) {
         self.items = items
     }
 
@@ -28,6 +28,6 @@ struct IntentItemListSection: View {
 
 #Preview {
     IncomesPreview { preview in
-        IntentItemListSection(preview.items)
+        IntentItemListSection(preview.items.compactMap(ItemEntity.init))
     }
 }

--- a/Incomes/Sources/Debug/Views/DebugListView.swift
+++ b/Incomes/Sources/Debug/Views/DebugListView.swift
@@ -33,7 +33,7 @@ extension DebugListView: View {
                     Text("Debug option")
                 }
             }
-            if let tag = try? GetAllTagsIntent.perform(context).first {
+            if let tag = try? GetAllTagsIntent.perform(context).first?.model(in: context) {
                 Section {
                     NavigationLink(value: IncomesPath.itemList(tag)) {
                         Text("All Items")

--- a/Incomes/Sources/Home/Views/HomeListView.swift
+++ b/Incomes/Sources/Home/Views/HomeListView.swift
@@ -87,7 +87,7 @@ extension HomeListView: View {
                         name: Date.now.stringValueWithoutLocale(.yyyy),
                         type: .year
                     )
-                )
+                )?.model(in: context)
                 isIntroductionPresented = (
                     try? GetAllItemsCountIntent.perform(context).isZero
                 ) ?? false

--- a/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct GetItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]
+    typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
@@ -22,14 +22,15 @@ struct GetItemsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.context.fetch(
+        let items = try input.context.fetch(
             .items(.dateIsSameMonthAs(input.date))
         )
+        return items.compactMap(ItemEntity.init)
     }
 
     @MainActor
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
         let items = try Self.perform((context: modelContainer.mainContext, date: date))
-        return .result(value: items.compactMap(ItemEntity.init))
+        return .result(value: items)
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct GetNextItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
@@ -24,16 +24,19 @@ struct GetNextItemsIntent: AppIntent, IntentPerformer {
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsAfter(input.date), order: .forward)
         guard let item = try input.context.fetchFirst(descriptor) else {
-            return nil
+            return .empty
         }
-        return try input.context.fetch(.items(.dateIsSameDayAs(item.localDate)))
+        let items = try input.context.fetch(
+            .items(.dateIsSameDayAs(item.localDate))
+        )
+        return items.compactMap(ItemEntity.init)
     }
 
     @MainActor
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
-        guard let items = try Self.perform((context: modelContainer.mainContext, date: date)) else {
-            return .result(value: .empty)
-        }
-        return .result(value: items.compactMap(ItemEntity.init))
+        let items = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        )
+        return .result(value: items)
     }
 }

--- a/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct ShowItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
@@ -25,12 +25,15 @@ struct ShowItemsIntent: AppIntent, IntentPerformer {
         let items = try input.context.fetch(
             .items(.dateIsSameMonthAs(input.date))
         )
-        return items.isEmpty ? nil : items
+        return items.compactMap(ItemEntity.init)
     }
 
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let items = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        let items = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        )
+        guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct ShowNextItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
@@ -27,8 +27,10 @@ struct ShowNextItemsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let items = try Self.perform((context: modelContainer.mainContext, date: date)),
-              items.isNotEmpty else {
+        let items = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        )
+        guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct ShowPreviousItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
     private var date: Date
@@ -27,8 +27,10 @@ struct ShowPreviousItemsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let items = try Self.perform((context: modelContainer.mainContext, date: date)),
-              items.isNotEmpty else {
+        let items = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        )
+        guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct ShowRecentItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    typealias Output = [ItemEntity]
 
     @Dependency private var modelContainer: ModelContainer
 
@@ -25,8 +25,10 @@ struct ShowRecentItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try Self.perform((context: modelContainer.mainContext, date: date)),
-              items.isNotEmpty else {
+        let items = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        )
+        guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct ShowThisMonthChartsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    typealias Output = [ItemEntity]
 
     @Dependency private var modelContainer: ModelContainer
 
@@ -25,9 +25,13 @@ struct ShowThisMonthChartsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        let entities = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        )
+        guard entities.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
+        let items = try entities.compactMap { try $0.model(in: modelContainer.mainContext) }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {
             IntentChartSectionGroup(.items(.idsAre(items.map(\.id))))
                 .modelContainer(modelContainer)

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct ShowThisMonthItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    typealias Output = [ItemEntity]
 
     @Dependency private var modelContainer: ModelContainer
 
@@ -25,7 +25,10 @@ struct ShowThisMonthItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        let items = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        )
+        guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
@@ -12,7 +12,7 @@ import SwiftUtilities
 
 struct ShowUpcomingItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [Item]?
+    typealias Output = [ItemEntity]
 
     @Dependency private var modelContainer: ModelContainer
 
@@ -25,8 +25,10 @@ struct ShowUpcomingItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let items = try Self.perform((context: modelContainer.mainContext, date: date)),
-              items.isNotEmpty else {
+        let items = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        )
+        guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: date.stringValue(.yyyyMMM))) {

--- a/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
@@ -4,19 +4,20 @@ import SwiftUtilities
 
 struct GetAllTagsIntent: AppIntent, IntentPerformer {
     typealias Input = ModelContext
-    typealias Output = [Tag]
+    typealias Output = [TagEntity]
 
     @Dependency private var modelContainer: ModelContainer
 
     static let title: LocalizedStringResource = .init("Get All Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.fetch(.tags(.all))
+        let tags = try input.fetch(.tags(.all))
+        return tags.compactMap(TagEntity.init)
     }
 
     @MainActor
     func perform() throws -> some ReturnsValue<[TagEntity]> {
         let tags = try Self.perform(modelContainer.mainContext)
-        return .result(value: tags.compactMap(TagEntity.init))
+        return .result(value: tags)
     }
 }

--- a/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
@@ -16,7 +16,7 @@ struct GetHasDuplicateTagsIntent: AppIntent, IntentPerformer {
         let duplicates = try FindDuplicateTagsIntent.perform(
             (
                 context: context,
-                tags: tags.compactMap(TagEntity.init)
+                tags: tags
             )
         )
         return !duplicates.isEmpty

--- a/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
@@ -4,7 +4,7 @@ import SwiftUtilities
 
 struct GetTagByNameIntent: AppIntent, IntentPerformer {
     typealias Input = (context: ModelContext, name: String, type: TagType)
-    typealias Output = Tag?
+    typealias Output = TagEntity?
 
     @Parameter(title: "Name")
     private var name: String
@@ -16,16 +16,17 @@ struct GetTagByNameIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Tag By Name", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.context.fetchFirst(
+        let tag = try input.context.fetchFirst(
             .tags(.nameIs(input.name, type: input.type))
         )
+        return tag.flatMap(TagEntity.init)
     }
 
     @MainActor
     func perform() throws -> some ReturnsValue<TagEntity?> {
-        let tag = try Self.perform(
+        let result = try Self.perform(
             (context: modelContainer.mainContext, name: name, type: type)
         )
-        return .result(value: tag.flatMap(TagEntity.init))
+        return .result(value: result)
     }
 }

--- a/Incomes/Sources/Tag/Models/TagEntity.swift
+++ b/Incomes/Sources/Tag/Models/TagEntity.swift
@@ -7,6 +7,7 @@
 //
 
 import AppIntents
+import SwiftData
 import SwiftUtilities
 
 @Observable
@@ -76,5 +77,15 @@ extension TagEntity {
         case .none:
             name
         }
+    }
+
+    func model(in context: ModelContext) throws -> Tag {
+        guard
+            let id = try? PersistentIdentifier(base64Encoded: id),
+            let model = try context.fetchFirst(.tags(.idIs(id)))
+        else {
+            throw TagError.tagNotFound
+        }
+        return model
     }
 }

--- a/Incomes/Sources/Tag/Models/TagEntityQuery.swift
+++ b/Incomes/Sources/Tag/Models/TagEntityQuery.swift
@@ -45,7 +45,6 @@ struct TagEntityQuery: EntityStringQuery {
                     )
             }
         }
-        .compactMap(TagEntity.init)
     }
 
     @MainActor
@@ -62,6 +61,5 @@ struct TagEntityQuery: EntityStringQuery {
                 $0.type == type
             }
         }
-        .compactMap(TagEntity.init)
     }
 }


### PR DESCRIPTION
## Summary
- return empty arrays from item intents instead of optionals
- adapt show intents to check for empty results

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68551216ca808320a283b89a231c0512