### PR TITLE
Update intent inputs to use ModelContainer

### DIFF
--- a/Incomes/Sources/Home/Components/HomeYearSection.swift
+++ b/Incomes/Sources/Home/Components/HomeYearSection.swift
@@ -48,7 +48,7 @@ struct HomeYearSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.compactMap(ItemEntity.init).forEach {
-                        try DeleteItemIntent.perform((context: context, item: $0))
+                        try DeleteItemIntent.perform((container: context.modelContainer, item: $0))
                     }
                     Haptic.success.impact()
                 } catch {

--- a/Incomes/Sources/Item/Components/DeleteItemButton.swift
+++ b/Incomes/Sources/Item/Components/DeleteItemButton.swift
@@ -44,7 +44,7 @@ extension DeleteItemButton: View {
         ) {
             Button(role: .destructive) {
                 do {
-                    try DeleteItemIntent.perform((context: context, item: item))
+                    try DeleteItemIntent.perform((container: context.modelContainer, item: item))
                     Haptic.success.impact()
                 } catch {
                     assertionFailure(error.localizedDescription)

--- a/Incomes/Sources/Item/Components/ItemListSection.swift
+++ b/Incomes/Sources/Item/Components/ItemListSection.swift
@@ -50,7 +50,7 @@ struct ItemListSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.forEach {
-                        try DeleteItemIntent.perform((context: context, item: $0))
+                        try DeleteItemIntent.perform((container: context.modelContainer, item: $0))
                     }
                     Haptic.success.impact()
                 } catch {

--- a/Incomes/Sources/Item/Components/ListItem.swift
+++ b/Incomes/Sources/Item/Components/ListItem.swift
@@ -76,7 +76,7 @@ struct ListItem: View {
         ) {
             Button(role: .destructive) {
                 do {
-                    try DeleteItemIntent.perform((context: context, item: item))
+                    try DeleteItemIntent.perform((container: context.modelContainer, item: item))
                     Haptic.success.impact()
                 } catch {
                     assertionFailure(error.localizedDescription)

--- a/Incomes/Sources/Item/Components/TagItemListSection.swift
+++ b/Incomes/Sources/Item/Components/TagItemListSection.swift
@@ -48,7 +48,7 @@ extension TagItemListSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.forEach {
-                        try DeleteItemIntent.perform((context: context, item: $0))
+                        try DeleteItemIntent.perform((container: context.modelContainer, item: $0))
                     }
                     Haptic.success.impact()
                 } catch {

--- a/Incomes/Sources/Item/Intents/Create/CreateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Create/CreateItemIntent.swift
@@ -12,7 +12,7 @@ import SwiftUI
 import SwiftUtilities
 
 struct CreateItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date, content: String, income: Decimal, outgo: Decimal, category: String, repeatCount: Int)
+    typealias Input = (container: ModelContainer, date: Date, content: String, income: Decimal, outgo: Decimal, category: String, repeatCount: Int)
     typealias Output = ItemEntity
 
     @Parameter(title: "Date", kind: .date)
@@ -33,8 +33,9 @@ struct CreateItemIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Create Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, date, content, income, outgo, category, repeatCount) = input
+        let (container, date, content, income, outgo, category, repeatCount) = input
         var items = [Item]()
+        let context = container.mainContext
 
         let repeatID = UUID()
 
@@ -98,7 +99,7 @@ struct CreateItemIntent: AppIntent, IntentPerformer {
 
         let item = try Self.perform(
             (
-                context: modelContainer.mainContext,
+                container: modelContainer,
                 date: date,
                 content: content,
                 income: income.amount,

--- a/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteAllItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = Void
 
     @Dependency private var modelContainer: ModelContainer
@@ -11,7 +11,7 @@ struct DeleteAllItemsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Delete All Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let context = input
+        let context = input.mainContext
         let items = try context.fetch(FetchDescriptor<Item>())
         items.forEach {
             $0.delete()
@@ -22,7 +22,7 @@ struct DeleteAllItemsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some IntentResult {
-        try Self.perform(modelContainer.mainContext)
+        try Self.perform(modelContainer)
         return .result()
     }
 }

--- a/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, item: ItemEntity)
+    typealias Input = (container: ModelContainer, item: ItemEntity)
     typealias Output = Void
 
     @Parameter(title: "Item")
@@ -14,7 +14,8 @@ struct DeleteItemIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Delete Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity) = input
+        let (container, entity) = input
+        let context = container.mainContext
         guard
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
             let model = try context.fetchFirst(.items(.idIs(id)))
@@ -28,7 +29,7 @@ struct DeleteItemIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, item: item))
+        try Self.perform((container: modelContainer, item: item))
         return .result()
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetAllItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetAllItemsCountIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetAllItemsCountIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = Int
 
     @Dependency private var modelContainer: ModelContainer
@@ -11,11 +11,11 @@ struct GetAllItemsCountIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get All Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.fetchCount(.items(.all))
+        try input.mainContext.fetchCount(.items(.all))
     }
 
     @MainActor
     func perform() throws -> some ReturnsValue<Int> {
-        .result(value: try Self.perform(modelContainer.mainContext))
+        .result(value: try Self.perform(modelContainer))
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
@@ -22,7 +22,7 @@ struct GetItemsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let items = try input.context.fetch(
+        let items = try input.container.mainContext.fetch(
             .items(.dateIsSameMonthAs(input.date))
         )
         return items.compactMap(ItemEntity.init)
@@ -30,7 +30,7 @@ struct GetItemsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
-        let items = try Self.perform((context: modelContainer.mainContext, date: date))
+        let items = try Self.perform((container: modelContainer, date: date))
         return .result(value: items)
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemContentIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemContentIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetNextItemContentIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = String?
 
     @Parameter(title: "Date", kind: .date)
@@ -22,7 +22,7 @@ struct GetNextItemContentIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Next Item Content", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {
+        guard let item = try GetNextItemIntent.perform((container: input.container, date: input.date)) else {
             return nil
         }
         return item.content
@@ -30,7 +30,7 @@ struct GetNextItemContentIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<String?> {
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try GetNextItemIntent.perform((container: modelContainer, date: date)) else {
             return .result(value: nil)
         }
         return .result(value: item.content)

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemDateIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemDateIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetNextItemDateIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = Date?
 
     @Parameter(title: "Date", kind: .date)
@@ -22,7 +22,7 @@ struct GetNextItemDateIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Next Item Date", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {
+        guard let item = try GetNextItemIntent.perform((container: input.container, date: input.date)) else {
             return nil
         }
         return item.date
@@ -30,7 +30,7 @@ struct GetNextItemDateIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<Date?> {
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try GetNextItemIntent.perform((container: modelContainer, date: date)) else {
             return .result(value: nil)
         }
         return .result(value: item.date)

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetNextItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = ItemEntity?
 
     @Parameter(title: "Date", kind: .date)
@@ -23,7 +23,7 @@ struct GetNextItemIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsAfter(input.date), order: .forward)
-        guard let item = try input.context.fetchFirst(descriptor) else {
+        guard let item = try input.container.mainContext.fetchFirst(descriptor) else {
             return nil
         }
         return .init(item)
@@ -31,7 +31,7 @@ struct GetNextItemIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<ItemEntity?> {
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try Self.perform((container: modelContainer, date: date)) else {
             return .result(value: nil)
         }
         return .result(value: item)

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemProfitIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemProfitIntent.swift
@@ -12,7 +12,7 @@ import SwiftUI
 import SwiftUtilities
 
 struct GetNextItemProfitIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = IntentCurrencyAmount?
 
     @Parameter(title: "Date", kind: .date)
@@ -23,7 +23,7 @@ struct GetNextItemProfitIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Next Item Profit", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {
+        guard let item = try GetNextItemIntent.perform((container: input.container, date: input.date)) else {
             return nil
         }
         let currencyCode = AppStorage(.currencyCode).wrappedValue
@@ -32,7 +32,7 @@ struct GetNextItemProfitIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<IntentCurrencyAmount?> {
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try GetNextItemIntent.perform((container: modelContainer, date: date)) else {
             return .result(value: nil)
         }
         let currencyCode = AppStorage(.currencyCode).wrappedValue

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetNextItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
@@ -23,10 +23,10 @@ struct GetNextItemsIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsAfter(input.date), order: .forward)
-        guard let item = try input.context.fetchFirst(descriptor) else {
+        guard let item = try input.container.mainContext.fetchFirst(descriptor) else {
             return .empty
         }
-        let items = try input.context.fetch(
+        let items = try input.container.mainContext.fetch(
             .items(.dateIsSameDayAs(item.localDate))
         )
         return items.compactMap(ItemEntity.init)
@@ -35,7 +35,7 @@ struct GetNextItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
         let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         return .result(value: items)
     }

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemContentIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemContentIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetPreviousItemContentIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = String?
 
     @Parameter(title: "Date", kind: .date)
@@ -27,7 +27,7 @@ struct GetPreviousItemContentIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<String?> {
-        guard let content = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let content = try Self.perform((container: modelContainer, date: date)) else {
             return .result(value: nil)
         }
         return .result(value: content)

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemDateIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemDateIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetPreviousItemDateIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = Date?
 
     @Parameter(title: "Date", kind: .date)
@@ -30,7 +30,7 @@ struct GetPreviousItemDateIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<Date?> {
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try Self.perform((container: modelContainer, date: date)) else {
             return .result(value: nil)
         }
         return .result(value: item)

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetPreviousItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = ItemEntity?
 
     @Parameter(title: "Date", kind: .date)
@@ -23,7 +23,7 @@ struct GetPreviousItemIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsBefore(input.date))
-        guard let item = try input.context.fetchFirst(descriptor) else {
+        guard let item = try input.container.mainContext.fetchFirst(descriptor) else {
             return nil
         }
         return .init(item)
@@ -31,7 +31,7 @@ struct GetPreviousItemIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<ItemEntity?> {
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try Self.perform((container: modelContainer, date: date)) else {
             return .result(value: nil)
         }
         return .result(value: item)

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemProfitIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemProfitIntent.swift
@@ -12,7 +12,7 @@ import SwiftUI
 import SwiftUtilities
 
 struct GetPreviousItemProfitIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = IntentCurrencyAmount?
 
     @Parameter(title: "Date", kind: .date)
@@ -32,7 +32,7 @@ struct GetPreviousItemProfitIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<IntentCurrencyAmount?> {
-        guard let amount = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let amount = try Self.perform((container: modelContainer, date: date)) else {
             return .result(value: nil)
         }
         return .result(value: amount)

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetPreviousItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
@@ -23,10 +23,10 @@ struct GetPreviousItemsIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) throws -> Output {
         let descriptor = FetchDescriptor.items(.dateIsBefore(input.date))
-        guard let item = try input.context.fetchFirst(descriptor) else {
+        guard let item = try input.container.mainContext.fetchFirst(descriptor) else {
             return .empty
         }
-        let items = try input.context.fetch(
+        let items = try input.container.mainContext.fetch(
             .items(.dateIsSameDayAs(item.localDate))
         )
         return items.compactMap(ItemEntity.init)
@@ -35,7 +35,7 @@ struct GetPreviousItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
         let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         return .result(value: items)
     }

--- a/Incomes/Sources/Item/Intents/Get/GetRepeatItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetRepeatItemsCountIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetRepeatItemsCountIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, repeatID: UUID)
+    typealias Input = (container: ModelContainer, repeatID: UUID)
     typealias Output = Int
 
     @Parameter(title: "Repeat ID")
@@ -14,7 +14,7 @@ struct GetRepeatItemsCountIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Repeat Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.context.fetchCount(.items(.repeatIDIs(input.repeatID)))
+        try input.container.mainContext.fetchCount(.items(.repeatIDIs(input.repeatID)))
     }
 
     @MainActor
@@ -22,6 +22,6 @@ struct GetRepeatItemsCountIntent: AppIntent, IntentPerformer {
         guard let uuid = UUID(uuidString: repeatID) else {
             throw DebugError.default
         }
-        return .result(value: try Self.perform((context: modelContainer.mainContext, repeatID: uuid)))
+        return .result(value: try Self.perform((container: modelContainer, repeatID: uuid)))
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetYearItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetYearItemsCountIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetYearItemsCountIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = Int
 
     @Parameter(title: "Date", kind: .date)
@@ -14,11 +14,11 @@ struct GetYearItemsCountIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Year Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.context.fetchCount(.items(.dateIsSameYearAs(input.date)))
+        try input.container.mainContext.fetchCount(.items(.dateIsSameYearAs(input.date)))
     }
 
     @MainActor
     func perform() throws -> some ReturnsValue<Int> {
-        .result(value: try Self.perform((context: modelContainer.mainContext, date: date)))
+        .result(value: try Self.perform((container: modelContainer, date: date)))
     }
 }

--- a/Incomes/Sources/Item/Intents/Show/CreateAndShowItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/CreateAndShowItemIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date, content: String, income: Double, outgo: Double, category: String, repeatCount: Int)
+    typealias Input = (container: ModelContainer, date: Date, content: String, income: Double, outgo: Double, category: String, repeatCount: Int)
     typealias Output = ItemEntity
 
     @Parameter(title: "Date", kind: .date)
@@ -38,7 +38,7 @@ struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
         }
         return try CreateItemIntent.perform(
             (
-                context: context,
+                container: context,
                 date: date,
                 content: content,
                 income: .init(income),
@@ -51,7 +51,7 @@ struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        let item = try Self.perform((context: modelContainer.mainContext,
+        let item = try Self.perform((container: modelContainer,
                                      date: date,
                                      content: content,
                                      income: income,

--- a/Incomes/Sources/Item/Intents/Show/ShowChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowChartsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowChartsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
@@ -22,7 +22,7 @@ struct ShowChartsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Show Charts", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let items = try input.context.fetch(
+        let items = try input.container.mainContext.fetch(
             .items(.dateIsSameMonthAs(input.date))
         )
         return items.compactMap(ItemEntity.init)
@@ -31,7 +31,7 @@ struct ShowChartsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let entities = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         guard entities.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
@@ -22,7 +22,7 @@ struct ShowItemsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Show Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let items = try input.context.fetch(
+        let items = try input.container.mainContext.fetch(
             .items(.dateIsSameMonthAs(input.date))
         )
         return items.compactMap(ItemEntity.init)
@@ -31,7 +31,7 @@ struct ShowItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowNextItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = ItemEntity?
 
     @Parameter(title: "Date", kind: .date)
@@ -22,12 +22,12 @@ struct ShowNextItemIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Show Next Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetNextItemIntent.perform((context: input.context, date: input.date))
+        try GetNextItemIntent.perform((container: input.container, date: input.date))
     }
 
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try GetNextItemIntent.perform((container: modelContainer, date: date)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowNextItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
@@ -28,7 +28,7 @@ struct ShowNextItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowPreviousItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = ItemEntity?
 
     @Parameter(title: "Date", kind: .date)
@@ -27,7 +27,7 @@ struct ShowPreviousItemIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try Self.perform((container: modelContainer, date: date)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowPreviousItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Parameter(title: "Date", kind: .date)
@@ -28,7 +28,7 @@ struct ShowPreviousItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowRecentItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = ItemEntity?
 
     @Dependency private var modelContainer: ModelContainer
@@ -25,7 +25,7 @@ struct ShowRecentItemIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try Self.perform((container: modelContainer, date: date)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowRecentItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Dependency private var modelContainer: ModelContainer
@@ -26,7 +26,7 @@ struct ShowRecentItemsIntent: AppIntent, IntentPerformer {
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
         let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowThisMonthChartsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Dependency private var modelContainer: ModelContainer
@@ -26,7 +26,7 @@ struct ShowThisMonthChartsIntent: AppIntent, IntentPerformer {
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
         let entities = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         guard entities.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowThisMonthItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Dependency private var modelContainer: ModelContainer
@@ -26,7 +26,7 @@ struct ShowThisMonthItemsIntent: AppIntent, IntentPerformer {
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
         let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowUpcomingItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = ItemEntity?
 
     @Dependency private var modelContainer: ModelContainer
@@ -19,13 +19,13 @@ struct ShowUpcomingItemIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Show Upcoming Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetNextItemIntent.perform((context: input.context, date: input.date))
+        try GetNextItemIntent.perform((container: input.container, date: input.date))
     }
 
     @MainActor
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try GetNextItemIntent.perform((container: modelContainer, date: date)) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
@@ -11,7 +11,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ShowUpcomingItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = [ItemEntity]
 
     @Dependency private var modelContainer: ModelContainer
@@ -26,7 +26,7 @@ struct ShowUpcomingItemsIntent: AppIntent, IntentPerformer {
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
         let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+            (container: modelContainer, date: date)
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Update/RecalculateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/RecalculateItemIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct RecalculateItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
+    typealias Input = (container: ModelContainer, date: Date)
     typealias Output = Void
 
     @Parameter(title: "Date", kind: .date)
@@ -15,12 +15,12 @@ struct RecalculateItemIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) throws -> Output {
         let calculator = BalanceCalculator()
-        try calculator.calculate(in: input.context, after: input.date)
+        try calculator.calculate(in: input.container.mainContext, after: input.date)
     }
 
     @MainActor
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, date: date))
+        try Self.perform((container: modelContainer, date: date))
         return .result()
     }
 }

--- a/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import SwiftUtilities
 
 struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
+    typealias Input = (container: ModelContainer, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
     typealias Output = Void
 
     @Parameter(title: "Item")
@@ -25,7 +25,8 @@ struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Update All Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity, date, content, income, outgo, category) = input
+        let (container, entity, date, content, income, outgo, category) = input
+        let context = container.mainContext
         guard
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
             let model = try context.fetchFirst(.items(.idIs(id)))
@@ -34,7 +35,7 @@ struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
         }
         try UpdateRepeatingItemsIntent.perform(
             (
-                context: context,
+                container: container,
                 item: entity,
                 date: date,
                 content: content,
@@ -57,7 +58,7 @@ struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
         }
         try Self.perform(
             (
-                context: modelContainer.mainContext,
+                container: modelContainer,
                 item: item,
                 date: date,
                 content: content,

--- a/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import SwiftUtilities
 
 struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
+    typealias Input = (container: ModelContainer, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
     typealias Output = Void
 
     @Parameter(title: "Item")
@@ -25,7 +25,8 @@ struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Update Future Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity, date, content, income, outgo, category) = input
+        let (container, entity, date, content, income, outgo, category) = input
+        let context = container.mainContext
         guard
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
             let model = try context.fetchFirst(.items(.idIs(id)))
@@ -34,7 +35,7 @@ struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
         }
         try UpdateRepeatingItemsIntent.perform(
             (
-                context: context,
+                container: container,
                 item: entity,
                 date: date,
                 content: content,
@@ -62,7 +63,7 @@ struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
         }
         try Self.perform(
             (
-                context: modelContainer.mainContext,
+                container: modelContainer,
                 item: item,
                 date: date,
                 content: content,

--- a/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import SwiftUtilities
 
 struct UpdateItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
+    typealias Input = (container: ModelContainer, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
     typealias Output = Void
 
     @Parameter(title: "Item")
@@ -25,7 +25,8 @@ struct UpdateItemIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Update Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity, date, content, income, outgo, category) = input
+        let (container, entity, date, content, income, outgo, category) = input
+        let context = container.mainContext
         guard
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
             let model = try context.fetchFirst(.items(.idIs(id)))
@@ -55,7 +56,7 @@ struct UpdateItemIntent: AppIntent, IntentPerformer {
         }
         try Self.perform(
             (
-                context: modelContainer.mainContext,
+                container: modelContainer,
                 item: item,
                 date: date,
                 content: content,

--- a/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
@@ -5,7 +5,7 @@ import SwiftUtilities
 
 struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
     typealias Input = (
-        context: ModelContext,
+        container: ModelContainer,
         item: ItemEntity,
         date: Date,
         content: String,
@@ -34,7 +34,8 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Update Repeating Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity, date, content, income, outgo, category, descriptor) = input
+        let (container, entity, date, content, income, outgo, category, descriptor) = input
+        let context = container.mainContext
         let components = Calendar.current.dateComponents(
             [.year, .month, .day],
             from: entity.date,
@@ -77,7 +78,7 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
         }
         try Self.perform(
             (
-                context: modelContainer.mainContext,
+                container: modelContainer,
                 item: item,
                 date: date,
                 content: content,

--- a/Incomes/Sources/Item/Views/ItemFormView.swift
+++ b/Incomes/Sources/Item/Views/ItemFormView.swift
@@ -219,7 +219,7 @@ private extension ItemFormView {
             if let entity = item,
                let model = try? entity.model(in: context),
                try GetRepeatItemsCountIntent.perform(
-                (context: context, repeatID: model.repeatID)
+                (container: context.modelContainer, repeatID: model.repeatID)
                ) > 1 {
                 presentToActionSheet()
             } else {

--- a/Incomes/Sources/Item/Views/RecalculateView.swift
+++ b/Incomes/Sources/Item/Views/RecalculateView.swift
@@ -37,7 +37,7 @@ struct RecalculateView: View {
                         isRecalculating = true
                         do {
                             try RecalculateItemIntent.perform(
-                                (context: context, date: selectedDate)
+                                (container: context.modelContainer, date: selectedDate)
                             )
                             try await Task.sleep(for: .seconds(5))
                         } catch {

--- a/Incomes/Sources/Item/Views/YearChartsView.swift
+++ b/Incomes/Sources/Item/Views/YearChartsView.swift
@@ -32,7 +32,7 @@ struct YearChartsView: View {
             }
             ToolbarItem(placement: .status) {
                 if let count = try? GetYearItemsCountIntent.perform(
-                    (context: context, date: date)
+                    (container: context.modelContainer, date: date)
                 ) {
                     Text("\(count) Items")
                         .font(.footnote)

--- a/Incomes/Sources/Notification/Models/NotificationService.swift
+++ b/Incomes/Sources/Notification/Models/NotificationService.swift
@@ -51,7 +51,7 @@ final class NotificationService: NSObject {
     }
 
     func sendTestNotification() {
-        guard let item = try? GetNextItemIntent.perform((context: modelContainer.mainContext, date: .now)) else {
+        guard let item = try? GetNextItemIntent.perform((container: modelContainer, date: .now)) else {
             return
         }
 

--- a/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteAllTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = Void
 
     @Dependency private var modelContainer: ModelContainer
@@ -20,7 +20,7 @@ struct DeleteAllTagsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some IntentResult {
-        try Self.perform(modelContainer.mainContext)
+        try Self.perform(modelContainer)
         return .result()
     }
 }

--- a/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct DeleteTagIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, tag: TagEntity)
+    typealias Input = (container: ModelContainer, tag: TagEntity)
     typealias Output = Void
 
     @Parameter(title: "Tag")
@@ -24,7 +24,7 @@ struct DeleteTagIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, tag: tag))
+        try Self.perform((container: modelContainer, tag: tag))
         return .result()
     }
 }

--- a/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct FindDuplicateTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, tags: [TagEntity])
+    typealias Input = (container: ModelContainer, tags: [TagEntity])
     typealias Output = [TagEntity]
 
     @Parameter(title: "Tags")
@@ -33,7 +33,7 @@ struct FindDuplicateTagsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<[TagEntity]> {
-        let result = try Self.perform((context: modelContainer.mainContext, tags: tags))
+        let result = try Self.perform((container: modelContainer, tags: tags))
         return .result(value: result)
     }
 }

--- a/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetAllTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = [TagEntity]
 
     @Dependency private var modelContainer: ModelContainer
@@ -17,7 +17,7 @@ struct GetAllTagsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<[TagEntity]> {
-        let tags = try Self.perform(modelContainer.mainContext)
+        let tags = try Self.perform(modelContainer)
         return .result(value: tags)
     }
 }

--- a/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetHasDuplicateTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
+    typealias Input = ModelContainer
     typealias Output = Bool
 
     @Dependency private var modelContainer: ModelContainer
@@ -24,7 +24,7 @@ struct GetHasDuplicateTagsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some ReturnsValue<Bool> {
-        let result = try Self.perform(modelContainer.mainContext)
+        let result = try Self.perform(modelContainer)
         return .result(value: result)
     }
 }

--- a/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetTagByIDIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, id: String)
+    typealias Input = (container: ModelContainer, id: String)
     typealias Output = TagEntity?
 
     @Parameter(title: "Tag ID")
@@ -15,7 +15,7 @@ struct GetTagByIDIntent: AppIntent, IntentPerformer {
 
     static func perform(_ input: Input) throws -> Output {
         let persistentID = try PersistentIdentifier(base64Encoded: input.id)
-        guard let tag = try input.context.fetchFirst(
+        guard let tag = try input.container.mainContext.fetchFirst(
             .tags(.idIs(persistentID))
         ) else {
             return nil
@@ -26,7 +26,7 @@ struct GetTagByIDIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ReturnsValue<TagEntity?> {
         guard let tagEntity = try Self.perform(
-            (context: modelContainer.mainContext, id: id)
+            (container: modelContainer, id: id)
         ) else {
             return .result(value: nil)
         }

--- a/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct GetTagByNameIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, name: String, type: TagType)
+    typealias Input = (container: ModelContainer, name: String, type: TagType)
     typealias Output = TagEntity?
 
     @Parameter(title: "Name")
@@ -16,7 +16,7 @@ struct GetTagByNameIntent: AppIntent, IntentPerformer {
     static let title: LocalizedStringResource = .init("Get Tag By Name", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let tag = try input.context.fetchFirst(
+        let tag = try input.container.mainContext.fetchFirst(
             .tags(.nameIs(input.name, type: input.type))
         )
         return tag.flatMap(TagEntity.init)
@@ -25,7 +25,7 @@ struct GetTagByNameIntent: AppIntent, IntentPerformer {
     @MainActor
     func perform() throws -> some ReturnsValue<TagEntity?> {
         let result = try Self.perform(
-            (context: modelContainer.mainContext, name: name, type: type)
+            (container: modelContainer, name: name, type: type)
         )
         return .result(value: result)
     }

--- a/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct MergeDuplicateTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, tags: [TagEntity])
+    typealias Input = (container: ModelContainer, tags: [TagEntity])
     typealias Output = Void
 
     @Parameter(title: "Tags")
@@ -31,13 +31,13 @@ struct MergeDuplicateTagsIntent: AppIntent, IntentPerformer {
             item.modify(tags: tags)
         }
         try children.compactMap(TagEntity.init).forEach { child in
-            try DeleteTagIntent.perform((context: context, tag: child))
+            try DeleteTagIntent.perform((container: context.modelContainer, tag: child))
         }
     }
 
     @MainActor
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, tags: tags))
+        try Self.perform((container: modelContainer, tags: tags))
         return .result()
     }
 }

--- a/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
@@ -3,7 +3,7 @@ import SwiftData
 import SwiftUtilities
 
 struct ResolveDuplicateTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, tags: [TagEntity])
+    typealias Input = (container: ModelContainer, tags: [TagEntity])
     typealias Output = Void
 
     @Parameter(title: "Tags")
@@ -32,7 +32,7 @@ struct ResolveDuplicateTagsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, tags: tags))
+        try Self.perform((container: modelContainer, tags: tags))
         return .result()
     }
 }

--- a/Incomes/Sources/Tag/Models/TagEntityQuery.swift
+++ b/Incomes/Sources/Tag/Models/TagEntityQuery.swift
@@ -17,7 +17,7 @@ struct TagEntityQuery: EntityStringQuery {
         try identifiers.compactMap { id in
             try GetTagByIDIntent.perform(
                 (
-                    context: modelContainer.mainContext,
+                    container: modelContainer,
                     id: id
                 )
             )

--- a/Incomes/Sources/Tag/Views/TagListView.swift
+++ b/Incomes/Sources/Tag/Views/TagListView.swift
@@ -84,10 +84,10 @@ struct TagListView: View {
                     try tags
                         .compactMap(TagEntity.init)
                         .forEach {
-                            try DeleteTagIntent.perform((context: context, tag: $0))
+                            try DeleteTagIntent.perform((container: context.modelContainer, tag: $0))
                         }
                     try items.compactMap(ItemEntity.init).forEach {
-                        try DeleteItemIntent.perform((context: context, item: $0))
+                        try DeleteItemIntent.perform((container: context.modelContainer, item: $0))
                     }
                     willDeleteTags = .empty
                     Haptic.success.impact()


### PR DESCRIPTION
## Summary
- update all intent inputs from `ModelContext` to `ModelContainer`
- adjust call sites and views to pass a `ModelContainer`
- refine context handling in `CreateItemIntent`
- streamline context extraction in update and delete intents

## Testing
- `pre-commit run --files $(git ls-files '*.swift' | tr '\n' ' ')` *(fails: command not found)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c85d394c8320ab79c6d339a44929