### PR TITLE
Fix compile errors with container inputs

### DIFF
--- a/Incomes/Sources/Home/Components/HomeYearSection.swift
+++ b/Incomes/Sources/Home/Components/HomeYearSection.swift
@@ -48,7 +48,12 @@ struct HomeYearSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.compactMap(ItemEntity.init).forEach {
-                        try DeleteItemIntent.perform((context: context, item: $0))
+                        try DeleteItemIntent.perform(
+                            (
+                                container: context.modelContainer,
+                                item: $0
+                            )
+                        )
                     }
                     Haptic.success.impact()
                 } catch {

--- a/Incomes/Sources/Item/Components/DeleteItemButton.swift
+++ b/Incomes/Sources/Item/Components/DeleteItemButton.swift
@@ -44,7 +44,12 @@ extension DeleteItemButton: View {
         ) {
             Button(role: .destructive) {
                 do {
-                    try DeleteItemIntent.perform((context: context, item: item))
+                    try DeleteItemIntent.perform(
+                        (
+                            container: context.modelContainer,
+                            item: item
+                        )
+                    )
                     Haptic.success.impact()
                 } catch {
                     assertionFailure(error.localizedDescription)

--- a/Incomes/Sources/Item/Components/ItemListSection.swift
+++ b/Incomes/Sources/Item/Components/ItemListSection.swift
@@ -50,7 +50,12 @@ struct ItemListSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.forEach {
-                        try DeleteItemIntent.perform((context: context, item: $0))
+                        try DeleteItemIntent.perform(
+                            (
+                                container: context.modelContainer,
+                                item: $0
+                            )
+                        )
                     }
                     Haptic.success.impact()
                 } catch {

--- a/Incomes/Sources/Item/Components/ListItem.swift
+++ b/Incomes/Sources/Item/Components/ListItem.swift
@@ -76,7 +76,12 @@ struct ListItem: View {
         ) {
             Button(role: .destructive) {
                 do {
-                    try DeleteItemIntent.perform((context: context, item: item))
+                    try DeleteItemIntent.perform(
+                        (
+                            container: context.modelContainer,
+                            item: item
+                        )
+                    )
                     Haptic.success.impact()
                 } catch {
                     assertionFailure(error.localizedDescription)

--- a/Incomes/Sources/Item/Components/TagItemListSection.swift
+++ b/Incomes/Sources/Item/Components/TagItemListSection.swift
@@ -48,7 +48,12 @@ extension TagItemListSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.forEach {
-                        try DeleteItemIntent.perform((context: context, item: $0))
+                        try DeleteItemIntent.perform(
+                            (
+                                container: context.modelContainer,
+                                item: $0
+                            )
+                        )
                     }
                     Haptic.success.impact()
                 } catch {

--- a/Incomes/Sources/Item/Views/ItemFormView.swift
+++ b/Incomes/Sources/Item/Views/ItemFormView.swift
@@ -219,7 +219,10 @@ private extension ItemFormView {
             if let entity = item,
                let model = try? entity.model(in: context),
                try GetRepeatItemsCountIntent.perform(
-                (context: context, repeatID: model.repeatID)
+                (
+                    container: context.modelContainer,
+                    repeatID: model.repeatID
+                )
                ) > 1 {
                 presentToActionSheet()
             } else {
@@ -238,7 +241,7 @@ private extension ItemFormView {
         do {
             try UpdateItemIntent.perform(
                 (
-                    context: context,
+                    container: context.modelContainer,
                     item: item,
                     date: date,
                     content: content,
@@ -262,7 +265,7 @@ private extension ItemFormView {
         do {
             try UpdateFutureItemsIntent.perform(
                 (
-                    context: context,
+                    container: context.modelContainer,
                     item: item,
                     date: date,
                     content: content,
@@ -286,7 +289,7 @@ private extension ItemFormView {
         do {
             try UpdateAllItemsIntent.perform(
                 (
-                    context: context,
+                    container: context.modelContainer,
                     item: item,
                     date: date,
                     content: content,
@@ -306,7 +309,7 @@ private extension ItemFormView {
         do {
             _ = try CreateItemIntent.perform(
                 (
-                    context: context,
+                    container: context.modelContainer,
                     date: date,
                     content: content,
                     income: income.decimalValue,

--- a/Incomes/Sources/Item/Views/RecalculateView.swift
+++ b/Incomes/Sources/Item/Views/RecalculateView.swift
@@ -37,7 +37,10 @@ struct RecalculateView: View {
                         isRecalculating = true
                         do {
                             try RecalculateItemIntent.perform(
-                                (context: context, date: selectedDate)
+                                (
+                                    container: context.modelContainer,
+                                    date: selectedDate
+                                )
                             )
                             try await Task.sleep(for: .seconds(5))
                         } catch {

--- a/Incomes/Sources/Item/Views/YearChartsView.swift
+++ b/Incomes/Sources/Item/Views/YearChartsView.swift
@@ -32,7 +32,10 @@ struct YearChartsView: View {
             }
             ToolbarItem(placement: .status) {
                 if let count = try? GetYearItemsCountIntent.perform(
-                    (context: context, date: date)
+                    (
+                        container: context.modelContainer,
+                        date: date
+                    )
                 ) {
                     Text("\(count) Items")
                         .font(.footnote)

--- a/Incomes/Sources/Main/Intents/OpenIncomesIntent.swift
+++ b/Incomes/Sources/Main/Intents/OpenIncomesIntent.swift
@@ -19,6 +19,7 @@ struct OpenIncomesIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_: Input) throws -> Output {}
 
+    @MainActor
     func perform() throws -> some IntentResult {
         try Self.perform(())
         return .result()

--- a/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
@@ -13,7 +13,6 @@ struct GetHasDuplicateTagsIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let container = input
-        let context = container.mainContext
         let tags = try GetAllTagsIntent.perform(container)
         let duplicates = try FindDuplicateTagsIntent.perform(
             (


### PR DESCRIPTION
## Summary
- adjust intent calls to pass `context.modelContainer`
- avoid unused variable in `GetHasDuplicateTagsIntent`
- mark `OpenIncomesIntent.perform()` as `@MainActor`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686534f0fa8c8320ba227d719155cbd2