### PR TITLE
Fix category not prefilled on edit

### DIFF
--- a/Incomes/Sources/Item/Views/ItemFormView.swift
+++ b/Incomes/Sources/Item/Views/ItemFormView.swift
@@ -175,6 +175,7 @@ struct ItemFormView: View {
                 content = item.content
                 income = item.income.isNotZero ? item.income.description : .empty
                 outgo = item.outgo.isNotZero ? item.outgo.description : .empty
+                category = item.category ?? .empty
             } else if let tag {
                 switch tag.type {
                 case .year:


### PR DESCRIPTION
## Summary
- ensure category text field is pre-populated when editing an item

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6865cfac0dec8320ad1a7b7c3e31923e