### PR TITLE
Use ModelContainer in tests

### DIFF
--- a/IncomesTests/Default/BalanceCalculatorTests.swift
+++ b/IncomesTests/Default/BalanceCalculatorTests.swift
@@ -12,122 +12,122 @@ import XCTest
 final class BalanceCalculatorTests: XCTestCase {
     func testCalculate() {
         XCTContext.runActivity(named: "Result is as expected when inserting") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
-            let item = try! Item.create(context: context,
+            let item = try! Item.create(context: container.mainContext,
                                         date: shiftedDate("2000-01-31T12:00:00Z"),
                                         content: "content",
                                         income: 200,
                                         outgo: 100,
                                         category: "category",
                                         repeatID: UUID())
-            context.insert(item)
-            try! calculator.calculate(in: context, after: item.localDate)
+            container.mainContext.insert(item)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 600)
             XCTAssertEqual(last.balance, 100)
         }
 
         XCTContext.runActivity(named: "Result is as expected when inserting first") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
-            let item = try! Item.create(context: context,
+            let item = try! Item.create(context: container.mainContext,
                                         date: shiftedDate("2001-01-01T00:00:00Z"),
                                         content: "content",
                                         income: 200,
                                         outgo: 100,
                                         category: "category",
                                         repeatID: UUID())
-            context.insert(item)
-            try! calculator.calculate(in: context, after: item.localDate)
+            container.mainContext.insert(item)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 600)
             XCTAssertEqual(last.balance, 100)
         }
 
         XCTContext.runActivity(named: "Result is as expected when inserting last") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
-            let item = try! Item.create(context: context,
+            let item = try! Item.create(context: container.mainContext,
                                         date: shiftedDate("2000-01-01T00:00:00Z"),
                                         content: "content",
                                         income: 200,
                                         outgo: 100,
                                         category: "category",
                                         repeatID: UUID())
-            context.insert(item)
-            try! calculator.calculate(in: context, after: item.localDate)
+            container.mainContext.insert(item)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 600)
             XCTAssertEqual(last.balance, 100)
         }
 
         XCTContext.runActivity(named: "Result is as expected when updating") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
                 items.append(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
             let item = items[1]
             try! item.modify(date: shiftedDate("2000-02-01T12:00:00Z"),
@@ -136,33 +136,33 @@ final class BalanceCalculatorTests: XCTestCase {
                              outgo: 100,
                              category: "category",
                              repeatID: UUID())
-            try! calculator.calculate(in: context, after: item.localDate)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 600)
             XCTAssertEqual(last.balance, 100)
         }
 
         XCTContext.runActivity(named: "Result is as expected when updating first") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
                 items.append(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
             let item = items[0]
             try! item.modify(date: shiftedDate("2000-01-01T12:00:00Z"),
@@ -171,33 +171,33 @@ final class BalanceCalculatorTests: XCTestCase {
                              outgo: 100,
                              category: "category",
                              repeatID: UUID())
-            try! calculator.calculate(in: context, after: item.localDate)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 600)
             XCTAssertEqual(last.balance, 200)
         }
 
         XCTContext.runActivity(named: "Result is as expected when updating last") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
                 items.append(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
             let item = items[4]
             try! item.modify(date: shiftedDate("2000-05-01T12:00:00Z"),
@@ -206,33 +206,33 @@ final class BalanceCalculatorTests: XCTestCase {
                              outgo: 100,
                              category: "category",
                              repeatID: UUID())
-            try! calculator.calculate(in: context, after: item.localDate)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 600)
             XCTAssertEqual(last.balance, 100)
         }
 
         XCTContext.runActivity(named: "Result is as expected when changing order") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
                 items.append(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
             let item = items[4]
             try! item.modify(date: shiftedDate("1999-12-31T00:00:00Z"),
@@ -241,100 +241,100 @@ final class BalanceCalculatorTests: XCTestCase {
                              outgo: 100,
                              category: "category",
                              repeatID: UUID())
-            try! calculator.calculate(in: context, after: item.localDate)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 600)
             XCTAssertEqual(last.balance, 200)
         }
 
         XCTContext.runActivity(named: "Result is as expected when deleting") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
                 items.append(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
             let item = items[1]
-            context.delete(item)
-            try! calculator.calculate(in: context, after: item.localDate)
+            container.mainContext.delete(item)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 400)
             XCTAssertEqual(last.balance, 100)
         }
 
         XCTContext.runActivity(named: "Result is as expected when deleting first") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
                 items.append(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
             let item = items[0]
-            context.delete(item)
-            try! calculator.calculate(in: context, after: item.localDate)
+            container.mainContext.delete(item)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 400)
             XCTAssertEqual(last.balance, 100)
         }
 
         XCTContext.runActivity(named: "Result is as expected when deleting last") { _ in
-            let context = testContext
+            let container = testContainer
             let calculator = BalanceCalculator()
 
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: context,
+                let item = try! Item.create(context: container.mainContext,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
                                             outgo: 100,
                                             category: "category",
                                             repeatID: UUID())
-                context.insert(item)
+                container.mainContext.insert(item)
                 items.append(item)
             }
-            try! calculator.calculate(in: context, after: .distantPast)
+            try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
             let item = items[4]
-            context.delete(item)
-            try! calculator.calculate(in: context, after: item.localDate)
+            container.mainContext.delete(item)
+            try! calculator.calculate(in: container.mainContext, after: item.localDate)
 
-            let first = fetchItems(context).first!
-            let last = fetchItems(context).last!
+            let first = fetchItems(container).first!
+            let last = fetchItems(container).last!
 
             XCTAssertEqual(first.balance, 400)
             XCTAssertEqual(last.balance, 100)

--- a/IncomesTests/Default/Intent/CreateItemIntentTest.swift
+++ b/IncomesTests/Default/Intent/CreateItemIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct CreateItemIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -22,7 +22,7 @@ struct CreateItemIntentTest {
                 repeatCount: 1
             )
         )
-        let result = try #require(fetchItems(context).first)
+        let result = try #require(fetchItems(container).first)
         #expect(result.utcDate == isoDate("2000-01-01T00:00:00Z"))
         #expect(result.content == "content")
         #expect(result.balance == 100)
@@ -31,7 +31,7 @@ struct CreateItemIntentTest {
     @Test func performRepeat() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -40,7 +40,7 @@ struct CreateItemIntentTest {
                 repeatCount: 3
             )
         )
-        let items = fetchItems(context)
+        let items = fetchItems(container)
         #expect(items.count == 3)
         #expect(Set(items.map(\.repeatID)).count == 1)
     }

--- a/IncomesTests/Default/Intent/DeleteAllItemsIntentTest.swift
+++ b/IncomesTests/Default/Intent/DeleteAllItemsIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct DeleteAllItemsIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "contentA",
                 income: 100,
@@ -24,7 +24,7 @@ struct DeleteAllItemsIntentTest {
         )
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-02T12:00:00Z"),
                 content: "contentB",
                 income: 0,
@@ -33,8 +33,8 @@ struct DeleteAllItemsIntentTest {
                 repeatCount: 1
             )
         )
-        #expect(fetchItems(context).count == 2)
-        try DeleteAllItemsIntent.perform(context.container)
-        #expect(fetchItems(context).isEmpty)
+        #expect(fetchItems(container).count == 2)
+        try DeleteAllItemsIntent.perform(container)
+        #expect(fetchItems(container).isEmpty)
     }
 }

--- a/IncomesTests/Default/Intent/DeleteItemIntentTest.swift
+++ b/IncomesTests/Default/Intent/DeleteItemIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct DeleteItemIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         let item = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -22,8 +22,8 @@ struct DeleteItemIntentTest {
                 repeatCount: 1
             )
         )
-        #expect(!fetchItems(context).isEmpty)
-        try DeleteItemIntent.perform((container: context.container, item: item))
-        #expect(fetchItems(context).isEmpty)
+        #expect(!fetchItems(container).isEmpty)
+        try DeleteItemIntent.perform((container: container, item: item))
+        #expect(fetchItems(container).isEmpty)
     }
 }

--- a/IncomesTests/Default/Intent/DeleteTagIntentTest.swift
+++ b/IncomesTests/Default/Intent/DeleteTagIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct DeleteTagIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
-        let tag = try Tag.create(context: context, name: "name", type: .year)
-        #expect(try context.fetchCount(.tags(.all)) == 1)
-        try DeleteTagIntent.perform((container: context.container, tag: .init(tag)!))
-        #expect(try context.fetchCount(.tags(.all)) == 0)
+        let tag = try Tag.create(context: container.mainContext, name: "name", type: .year)
+        #expect(try container.mainContext.fetchCount(.tags(.all)) == 1)
+        try DeleteTagIntent.perform((container: container, tag: .init(tag)!))
+        #expect(try container.mainContext.fetchCount(.tags(.all)) == 0)
     }
 }

--- a/IncomesTests/Default/Intent/FindDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/FindDuplicateTagsIntentTest.swift
@@ -4,21 +4,21 @@ import Testing
 
 @MainActor
 struct FindDuplicateTagsIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
-        let tag1 = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)
-        let tag2 = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)
-        let tag3 = try Tag.createIgnoringDuplicates(context: context, name: "B", type: .yearMonth)
-        let tag4 = try Tag.createIgnoringDuplicates(context: context, name: "B", type: .yearMonth)
+        let tag1 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
+        let tag2 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
+        let tag3 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "B", type: .yearMonth)
+        let tag4 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "B", type: .yearMonth)
 
         let result = try FindDuplicateTagsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 tags: [tag1, tag2, tag3, tag4].compactMap(TagEntity.init)
             )
         )

--- a/IncomesTests/Default/Intent/GetAllItemsCountIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetAllItemsCountIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct GetAllItemsCountIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 100,
@@ -22,7 +22,7 @@ struct GetAllItemsCountIntentTest {
                 repeatCount: 1
             )
         )
-        let count = try GetAllItemsCountIntent.perform(context.container)
+        let count = try GetAllItemsCountIntent.perform(container)
         #expect(count == 1)
     }
 }

--- a/IncomesTests/Default/Intent/GetAllTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetAllTagsIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct GetAllTagsIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
-        _ = try Tag.create(context: context, name: "A", type: .year)
-        _ = try Tag.create(context: context, name: "B", type: .content)
-        let tags = try GetAllTagsIntent.perform(context.container)
+        _ = try Tag.create(context: container.mainContext, name: "A", type: .year)
+        _ = try Tag.create(context: container.mainContext, name: "B", type: .content)
+        let tags = try GetAllTagsIntent.perform(container)
         #expect(tags.count == 2)
     }
 }

--- a/IncomesTests/Default/Intent/GetHasDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetHasDuplicateTagsIntentTest.swift
@@ -4,27 +4,27 @@ import Testing
 
 @MainActor
 struct GetHasDuplicateTagsIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
-        #expect(try GetHasDuplicateTagsIntent.perform(context.container) == false)
+        #expect(try GetHasDuplicateTagsIntent.perform(container) == false)
 
-        let tag1 = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)
-        _ = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)
+        let tag1 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
+        _ = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
 
-        #expect(try GetHasDuplicateTagsIntent.perform(context.container) == true)
+        #expect(try GetHasDuplicateTagsIntent.perform(container) == true)
 
         try MergeDuplicateTagsIntent.perform(
             (
-                container: context.container,
-                tags: try context.fetch(.tags(.isSameWith(tag1))).compactMap(TagEntity.init)
+                container: container,
+                tags: try container.mainContext.fetch(.tags(.isSameWith(tag1))).compactMap(TagEntity.init)
             )
         )
 
-        #expect(try GetHasDuplicateTagsIntent.perform(context.container) == false)
+        #expect(try GetHasDuplicateTagsIntent.perform(container) == false)
     }
 }

--- a/IncomesTests/Default/Intent/GetNextItemIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetNextItemIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct GetNextItemIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "A",
                 income: 0,
@@ -24,7 +24,7 @@ struct GetNextItemIntentTest {
         )
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-02-01T12:00:00Z"),
                 content: "B",
                 income: 0,
@@ -33,7 +33,7 @@ struct GetNextItemIntentTest {
                 repeatCount: 1
             )
         )
-        let item = try #require(try GetNextItemIntent.perform((container: context.container, date: isoDate("2000-01-15T00:00:00Z"))))
+        let item = try #require(try GetNextItemIntent.perform((container: container, date: isoDate("2000-01-15T00:00:00Z"))))
         #expect(item.content == "B")
     }
 }

--- a/IncomesTests/Default/Intent/GetPreviousItemIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetPreviousItemIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct GetPreviousItemIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "A",
                 income: 0,
@@ -24,7 +24,7 @@ struct GetPreviousItemIntentTest {
         )
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-02-01T12:00:00Z"),
                 content: "B",
                 income: 0,
@@ -33,7 +33,7 @@ struct GetPreviousItemIntentTest {
                 repeatCount: 1
             )
         )
-        let item = try #require(try GetPreviousItemIntent.perform((container: context.container, date: isoDate("2000-02-15T00:00:00Z"))))
+        let item = try #require(try GetPreviousItemIntent.perform((container: container, date: isoDate("2000-02-15T00:00:00Z"))))
         #expect(item.content == "B")
     }
 }

--- a/IncomesTests/Default/Intent/GetRepeatItemsCountIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetRepeatItemsCountIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct GetRepeatItemsCountIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         let entity = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "A",
                 income: 0,
@@ -23,9 +23,9 @@ struct GetRepeatItemsCountIntentTest {
             )
         )
         let repeatID = try PersistentIdentifier(base64Encoded: entity.id)
-        let model = try #require(try context.fetchFirst(.items(.idIs(repeatID))))
+        let model = try #require(try container.mainContext.fetchFirst(.items(.idIs(repeatID))))
         let count = try GetRepeatItemsCountIntent.perform(
-            (container: context.container, repeatID: model.repeatID)
+            (container: container, repeatID: model.repeatID)
         )
         #expect(count == 2)
     }

--- a/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
@@ -4,19 +4,19 @@ import Testing
 
 @MainActor
 struct GetTagByIDIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
-        let model = try Tag.create(context: context, name: "name", type: .content)
+        let model = try Tag.create(context: container.mainContext, name: "name", type: .content)
         let id = try model.id.base64Encoded()
         let tagEntity = try #require(
             try GetTagByIDIntent.perform(
                 (
-                    container: context.container,
+                    container: container,
                     id: id
                 )
             )

--- a/IncomesTests/Default/Intent/GetTagByNameIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetTagByNameIntentTest.swift
@@ -4,18 +4,18 @@ import Testing
 
 @MainActor
 struct GetTagByNameIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
-        _ = try Tag.create(context: context, name: "name", type: .year)
+        _ = try Tag.create(context: container.mainContext, name: "name", type: .year)
         let tag = try #require(
             try GetTagByNameIntent.perform(
                 (
-                    container: context.container,
+                    container: container,
                     name: "name",
                     type: .year
                 )

--- a/IncomesTests/Default/Intent/GetYearItemsCountIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetYearItemsCountIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct GetYearItemsCountIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-02-01T12:00:00Z"),
                 content: "A",
                 income: 0,
@@ -23,7 +23,7 @@ struct GetYearItemsCountIntentTest {
             )
         )
         let count = try GetYearItemsCountIntent.perform(
-            (container: context.container, date: isoDate("2000-01-01T00:00:00Z"))
+            (container: container, date: isoDate("2000-01-01T00:00:00Z"))
         )
         #expect(count == 1)
     }

--- a/IncomesTests/Default/Intent/MergeDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/MergeDuplicateTagsIntentTest.swift
@@ -4,15 +4,15 @@ import Testing
 
 @MainActor
 struct MergeDuplicateTagsIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func mergeWhenTagsAreDifferent() throws {
         let item1 = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: .now,
             content: "contentA",
             income: .zero,
@@ -21,7 +21,7 @@ struct MergeDuplicateTagsIntentTest {
             repeatID: .init()
         )
         let item2 = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: .now,
             content: "contentB",
             income: .zero,
@@ -30,7 +30,7 @@ struct MergeDuplicateTagsIntentTest {
             repeatID: .init()
         )
         let item3 = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: .now,
             content: "contentC",
             income: .zero,
@@ -50,31 +50,31 @@ struct MergeDuplicateTagsIntentTest {
 
         try MergeDuplicateTagsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 tags: [tag1, tag2, tag3].compactMap(TagEntity.init)
             )
         )
 
-        #expect(try context.fetchCount(.tags(.nameIs("contentA", type: .content))) == 1)
-        #expect(try context.fetchCount(.tags(.nameIs("contentB", type: .content))) == 0)
-        #expect(try context.fetchCount(.tags(.nameIs("contentC", type: .content))) == 0)
+        #expect(try container.mainContext.fetchCount(.tags(.nameIs("contentA", type: .content))) == 1)
+        #expect(try container.mainContext.fetchCount(.tags(.nameIs("contentB", type: .content))) == 0)
+        #expect(try container.mainContext.fetchCount(.tags(.nameIs("contentC", type: .content))) == 0)
         #expect(item1.tags?.contains(tag1) == true)
         #expect(item2.tags?.contains(tag1) == true)
         #expect(item3.tags?.contains(tag1) == true)
     }
 
     @Test func mergeWhenTagsAreDuplicated() throws {
-        let tag1 = try Tag.createIgnoringDuplicates(context: context, name: "contentA", type: .content)
-        let tag2 = try Tag.createIgnoringDuplicates(context: context, name: "contentA", type: .content)
-        let tag3 = try Tag.createIgnoringDuplicates(context: context, name: "contentA", type: .content)
+        let tag1 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "contentA", type: .content)
+        let tag2 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "contentA", type: .content)
+        let tag3 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "contentA", type: .content)
 
         try MergeDuplicateTagsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 tags: [tag1, tag2, tag3].compactMap(TagEntity.init)
             )
         )
 
-        #expect(try context.fetchCount(.tags(.nameIs("contentA", type: .content))) == 1)
+        #expect(try container.mainContext.fetchCount(.tags(.nameIs("contentA", type: .content))) == 1)
     }
 }

--- a/IncomesTests/Default/Intent/RecalculateItemIntentTest.swift
+++ b/IncomesTests/Default/Intent/RecalculateItemIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct RecalculateItemIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         let entity = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T00:00:00Z"),
                 content: "content",
                 income: 100,
@@ -24,7 +24,7 @@ struct RecalculateItemIntentTest {
         )
         try UpdateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: entity,
                 date: entity.date,
                 content: entity.content,
@@ -33,8 +33,8 @@ struct RecalculateItemIntentTest {
                 category: entity.category ?? ""
             )
         )
-        try RecalculateItemIntent.perform((container: context.container, date: isoDate("1999-12-01T00:00:00Z")))
-        let item = try #require(fetchItems(context).first)
+        try RecalculateItemIntent.perform((container: container, date: isoDate("1999-12-01T00:00:00Z")))
+        let item = try #require(fetchItems(container).first)
         #expect(item.balance == 10)
     }
 }

--- a/IncomesTests/Default/Intent/ResolveDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/ResolveDuplicateTagsIntentTest.swift
@@ -4,28 +4,28 @@ import Testing
 
 @MainActor
 struct ResolveDuplicateTagsIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
-        let tag1 = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)
-        _ = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)
-        _ = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)
-        let tag4 = try Tag.createIgnoringDuplicates(context: context, name: "B", type: .yearMonth)
-        _ = try Tag.createIgnoringDuplicates(context: context, name: "B", type: .yearMonth)
+        let tag1 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
+        _ = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
+        _ = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
+        let tag4 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "B", type: .yearMonth)
+        _ = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "B", type: .yearMonth)
 
-        #expect(try context.fetchCount(.tags(.all)) == 5)
+        #expect(try container.mainContext.fetchCount(.tags(.all)) == 5)
 
         try ResolveDuplicateTagsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 tags: [tag1, tag4].compactMap(TagEntity.init)
             )
         )
 
-        #expect(try context.fetchCount(.tags(.all)) == 2)
+        #expect(try container.mainContext.fetchCount(.tags(.all)) == 2)
     }
 }

--- a/IncomesTests/Default/Intent/UpdateAllItemsIntentTest.swift
+++ b/IncomesTests/Default/Intent/UpdateAllItemsIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct UpdateAllItemsIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         let item = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -24,7 +24,7 @@ struct UpdateAllItemsIntentTest {
         )
         try UpdateAllItemsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: item,
                 date: isoDate("2001-01-02T12:00:00Z"),
                 content: "content2",
@@ -33,7 +33,7 @@ struct UpdateAllItemsIntentTest {
                 category: "category2"
             )
         )
-        let result = fetchItems(context).first!
+        let result = fetchItems(container).first!
         #expect(result.utcDate == isoDate("2001-01-02T00:00:00Z"))
         #expect(result.content == "content2")
         #expect(result.income == 100)
@@ -44,7 +44,7 @@ struct UpdateAllItemsIntentTest {
     @Test func performRepeat() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -55,8 +55,8 @@ struct UpdateAllItemsIntentTest {
         )
         try UpdateAllItemsIntent.perform(
             (
-                container: context.container,
-                item: ItemEntity(fetchItems(context)[1])!,
+                container: container,
+                item: ItemEntity(fetchItems(container)[1])!,
                 date: isoDate("2000-02-02T12:00:00Z"),
                 content: "content2",
                 income: 100,
@@ -64,9 +64,9 @@ struct UpdateAllItemsIntentTest {
                 category: "category2"
             )
         )
-        let first = fetchItems(context)[0]
-        let second = fetchItems(context)[1]
-        let last = fetchItems(context)[2]
+        let first = fetchItems(container)[0]
+        let second = fetchItems(container)[1]
+        let last = fetchItems(container)[2]
 
         #expect(first.utcDate == isoDate("2000-03-02T00:00:00Z"))
         #expect(first.content == "content2")

--- a/IncomesTests/Default/Intent/UpdateFutureItemsIntentTest.swift
+++ b/IncomesTests/Default/Intent/UpdateFutureItemsIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct UpdateFutureItemsIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         let item = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -24,7 +24,7 @@ struct UpdateFutureItemsIntentTest {
         )
         try UpdateFutureItemsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: item,
                 date: isoDate("2001-01-02T12:00:00Z"),
                 content: "content2",
@@ -33,7 +33,7 @@ struct UpdateFutureItemsIntentTest {
                 category: "category2"
             )
         )
-        let result = fetchItems(context).first!
+        let result = fetchItems(container).first!
         #expect(result.utcDate == isoDate("2001-01-02T00:00:00Z"))
         #expect(result.content == "content2")
         #expect(result.income == 100)
@@ -44,7 +44,7 @@ struct UpdateFutureItemsIntentTest {
     @Test func performRepeat() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -55,8 +55,8 @@ struct UpdateFutureItemsIntentTest {
         )
         try UpdateFutureItemsIntent.perform(
             (
-                container: context.container,
-                item: ItemEntity(fetchItems(context)[1])!,
+                container: container,
+                item: ItemEntity(fetchItems(container)[1])!,
                 date: isoDate("2000-02-02T12:00:00Z"),
                 content: "content2",
                 income: 100,
@@ -64,9 +64,9 @@ struct UpdateFutureItemsIntentTest {
                 category: "category2"
             )
         )
-        let first = fetchItems(context)[0]
-        let second = fetchItems(context)[1]
-        let last = fetchItems(context)[2]
+        let first = fetchItems(container)[0]
+        let second = fetchItems(container)[1]
+        let last = fetchItems(container)[2]
 
         #expect(first.utcDate == isoDate("2000-03-02T00:00:00Z"))
         #expect(first.content == "content2")

--- a/IncomesTests/Default/Intent/UpdateItemIntentTest.swift
+++ b/IncomesTests/Default/Intent/UpdateItemIntentTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct UpdateItemIntentTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func perform() throws {
         let item = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -24,7 +24,7 @@ struct UpdateItemIntentTest {
         )
         try UpdateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: item,
                 date: isoDate("2001-01-02T12:00:00Z"),
                 content: "content2",
@@ -33,7 +33,7 @@ struct UpdateItemIntentTest {
                 category: "category2"
             )
         )
-        let result = fetchItems(context).first!
+        let result = fetchItems(container).first!
         #expect(result.utcDate == isoDate("2001-01-02T00:00:00Z"))
         #expect(result.content == "content2")
         #expect(result.income == 100)
@@ -44,7 +44,7 @@ struct UpdateItemIntentTest {
     @Test func performRepeat() throws {
         _ = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -55,8 +55,8 @@ struct UpdateItemIntentTest {
         )
         try UpdateItemIntent.perform(
             (
-                container: context.container,
-                item: ItemEntity(fetchItems(context)[1])!,
+                container: container,
+                item: ItemEntity(fetchItems(container)[1])!,
                 date: isoDate("2000-02-02T12:00:00Z"),
                 content: "content2",
                 income: 100,
@@ -65,9 +65,9 @@ struct UpdateItemIntentTest {
             )
         )
 
-        let first = fetchItems(context)[0]
-        let second = fetchItems(context)[1]
-        let last = fetchItems(context)[2]
+        let first = fetchItems(container)[0]
+        let second = fetchItems(container)[1]
+        let last = fetchItems(container)[2]
 
         #expect(first.utcDate == isoDate("2000-03-01T00:00:00Z"))
         #expect(first.content == "content")

--- a/IncomesTests/Default/ItemEntityExtensionTest.swift
+++ b/IncomesTests/Default/ItemEntityExtensionTest.swift
@@ -4,16 +4,16 @@ import Testing
 
 @MainActor
 struct ItemEntityExtensionTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @Test func modelFetch() throws {
         let entity = try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: isoDate("2000-01-01T12:00:00Z"),
                 content: "content",
                 income: 200,
@@ -22,7 +22,7 @@ struct ItemEntityExtensionTest {
                 repeatCount: 1
             )
         )
-        let item = try entity.model(in: context)
+        let item = try entity.model(in: container.mainContext)
         #expect(item.content == "content")
         #expect(item.balance == 100)
     }

--- a/IncomesTests/IncomesTests.swift
+++ b/IncomesTests/IncomesTests.swift
@@ -43,6 +43,7 @@ let timeZones: [TimeZone] = [
     .init(identifier: "Europe/Minsk")!
 ]
 
+@MainActor
 func fetchItems(_ container: ModelContainer) -> [Item] {
     try! container.mainContext.fetch(.items(.all))
 }

--- a/IncomesTests/IncomesTests.swift
+++ b/IncomesTests/IncomesTests.swift
@@ -12,13 +12,11 @@ import XCTest
 
 final class IncomesTests: XCTestCase {}
 
-var testContext: ModelContext {
+var testContainer: ModelContainer {
     try! .init(
-        .init(
-            for: Item.self,
-            configurations: .init(
-                isStoredInMemoryOnly: true
-            )
+        for: Item.self,
+        configurations: .init(
+            isStoredInMemoryOnly: true
         )
     )
 }
@@ -45,6 +43,6 @@ let timeZones: [TimeZone] = [
     .init(identifier: "Europe/Minsk")!
 ]
 
-func fetchItems(_ context: ModelContext) -> [Item] {
-    try! context.fetch(.items(.all))
+func fetchItems(_ container: ModelContainer) -> [Item] {
+    try! container.mainContext.fetch(.items(.all))
 }

--- a/IncomesTests/TimeZone/ItemPredicateTest.swift
+++ b/IncomesTests/TimeZone/ItemPredicateTest.swift
@@ -14,10 +14,10 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ItemPredicateTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     // MARK: - All
@@ -26,11 +26,11 @@ struct ItemPredicateTest {
     func returnsAllItemsWithAllPredicate(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-01-01T00:00:00Z"), content: "One", income: 100, outgo: 0, category: "A", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-02-01T00:00:00Z"), content: "Two", income: 200, outgo: 0, category: "B", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-01-01T00:00:00Z"), content: "One", income: 100, outgo: 0, category: "A", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-02-01T00:00:00Z"), content: "Two", income: 200, outgo: 0, category: "B", repeatCount: 1))
 
         let predicate = ItemPredicate.all
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("One"))
@@ -44,10 +44,10 @@ struct ItemPredicateTest {
     func returnsNoItemsWithNonePredicate(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-01-01T00:00:00Z"), content: "One", income: 100, outgo: 0, category: "A", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-01-01T00:00:00Z"), content: "One", income: 100, outgo: 0, category: "A", repeatCount: 1))
 
         let predicate = ItemPredicate.none
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         #expect(items.isEmpty)
     }
@@ -59,11 +59,11 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let date = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
-        let tag = try Tag.create(context: context, name: "2024", type: .year)
+        let tag = try Tag.create(context: container.mainContext, name: "2024", type: .year)
         let predicate = ItemPredicate.tagIs(tag)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         try #require(items.count == 1)
         #expect(
@@ -93,11 +93,11 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let date = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
-        let tag = try Tag.create(context: context, name: "202401", type: .yearMonth)
+        let tag = try Tag.create(context: container.mainContext, name: "202401", type: .yearMonth)
         let predicate = ItemPredicate.tagIs(tag)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         try #require(items.count == 1)
         #expect(
@@ -127,11 +127,11 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let date = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
-        let tag = try Tag.create(context: context, name: "Content", type: .content)
+        let tag = try Tag.create(context: container.mainContext, name: "Content", type: .content)
         let predicate = ItemPredicate.tagAndYear(tag: tag, yearString: "2024")
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         try #require(items.count == 1)
         #expect(
@@ -163,10 +163,10 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsBefore(cutoff)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(!contents.contains("OnCutoff"))
@@ -178,11 +178,11 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-04-30T23:59:59Z"), content: "April", income: 1, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: cutoff, content: "May", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-04-30T23:59:59Z"), content: "April", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: cutoff, content: "May", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsBefore(cutoff)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("April"))
@@ -195,12 +195,12 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-04-01T00:00:00Z"), content: "EarlyApril", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-04-15T00:00:00Z"), content: "MidApril", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-04-01T00:00:00Z"), content: "EarlyApril", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-04-15T00:00:00Z"), content: "MidApril", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsBefore(cutoff)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("EarlyApril"))
@@ -214,11 +214,11 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-05-01T00:00:01Z"), content: "After", income: 1, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-04-30T23:59:59Z"), content: "Before", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-05-01T00:00:01Z"), content: "After", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-04-30T23:59:59Z"), content: "Before", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsAfter(cutoff)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("After"))
@@ -231,12 +231,12 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-05-02T00:00:00Z"), content: "MaySecond", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-06-01T00:00:00Z"), content: "June", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-05-02T00:00:00Z"), content: "MaySecond", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-06-01T00:00:00Z"), content: "June", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsAfter(cutoff)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("OnCutoff"))
@@ -250,10 +250,10 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoff = shiftedDate("2024-05-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: cutoff, content: "OnCutoff", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsAfter(cutoff)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("OnCutoff"))
@@ -264,11 +264,11 @@ struct ItemPredicateTest {
     func excludesDifferentYearSameMonth(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2023-02-15T00:00:00Z"), content: "2023Feb", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-02-15T00:00:00Z"), content: "2024Feb", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2023-02-15T00:00:00Z"), content: "2023Feb", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-02-15T00:00:00Z"), content: "2024Feb", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-02-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents == ["2024Feb"])
@@ -279,12 +279,12 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let baseDate = shiftedDate("2024-01-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-01-15T00:00:00Z"), content: "January", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-06-01T00:00:00Z"), content: "June", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2023-12-31T23:59:59Z"), content: "LastYear", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-01-15T00:00:00Z"), content: "January", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-06-01T00:00:00Z"), content: "June", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2023-12-31T23:59:59Z"), content: "LastYear", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameYearAs(baseDate)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("January"))
@@ -299,7 +299,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-01-01T00:00:00Z")
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JST_Jan1",
              income: 0,
@@ -309,7 +309,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-01-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("JST_Jan1"))
@@ -321,7 +321,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-12-31T23:59:59Z") // UTC: 2024-12-31T14:59:59Z
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JST_EndOfYear",
              income: 0,
@@ -331,7 +331,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-01-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("JST_EndOfYear"))
@@ -343,7 +343,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-01-01T00:00:00Z") // UTC: 2023-12-31T15:00:00Z
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JST_StartOfYear",
              income: 0,
@@ -353,7 +353,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-01-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         #expect(items.map(\.content).contains("JST_StartOfYear"))
     }
@@ -366,7 +366,7 @@ struct ItemPredicateTest {
         let jstDate2 = shiftedDate("2024-12-31T23:59:59Z")  // 2024-12-31T14:59:59Z
 
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate1,
              content: "StartJSTYear",
              income: 100,
@@ -375,7 +375,7 @@ struct ItemPredicateTest {
              repeatCount: 1)
         )
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate2,
              content: "EndJSTYear",
              income: 100,
@@ -385,7 +385,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameYearAs(shiftedDate("2024-01-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("StartJSTYear"))
@@ -399,7 +399,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-03-01T00:00:00Z")  // = 2024-02-29T15:00:00Z
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JST_MarchStart",
              income: 0,
@@ -409,7 +409,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-03-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         #expect(items.map(\.content).contains("JST_MarchStart"))
     }
 
@@ -419,7 +419,7 @@ struct ItemPredicateTest {
 
         let utcDate = shiftedDate("2024-03-01T00:00:00Z")
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: utcDate,
              content: "UTC_MarchStart",
              income: 0,
@@ -429,7 +429,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-03-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         #expect(items.map(\.content).contains("UTC_MarchStart"))
         #expect(items.count == 1)
     }
@@ -440,7 +440,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-02-01T00:00:00Z")
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JSTFebStart",
              income: 100,
@@ -450,8 +450,8 @@ struct ItemPredicateTest {
         )
         let jan = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-01-01T00:00:00Z"))
         let feb = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
-        let janItems = try context.fetch(.items(jan))
-        let febItems = try context.fetch(.items(feb))
+        let janItems = try container.mainContext.fetch(.items(jan))
+        let febItems = try container.mainContext.fetch(.items(feb))
         #expect(!janItems.map(\.content).contains("JSTFebStart"))
         #expect(febItems.map(\.content).contains("JSTFebStart"))
     }
@@ -462,7 +462,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-03-01T00:00:00Z")
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JSTMarStart",
              income: 100,
@@ -472,8 +472,8 @@ struct ItemPredicateTest {
         )
         let feb = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
         let mar = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-03-01T00:00:00Z"))
-        let febItems = try context.fetch(.items(feb))
-        let marItems = try context.fetch(.items(mar))
+        let febItems = try container.mainContext.fetch(.items(feb))
+        let marItems = try container.mainContext.fetch(.items(mar))
         #expect(!febItems.map(\.content).contains("JSTMarStart"))
         #expect(marItems.map(\.content).contains("JSTMarStart"))
     }
@@ -485,7 +485,7 @@ struct ItemPredicateTest {
         // 2024-02-29T23:59:59+0900 = 2024-02-29T14:59:59Z
         let jstDate = shiftedDate("2024-02-29T23:59:59Z")
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JSTEnd",
              income: 100,
@@ -495,7 +495,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         #expect(items.count == 1)  // Should pass if UTC-based correctly
     }
@@ -507,7 +507,7 @@ struct ItemPredicateTest {
         // 2024-02-01T00:00:00+0900 = 2024-01-31T15:00:00Z
         let jstDate = shiftedDate("2024-02-01T00:00:00Z")
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JSTBoundary",
              income: 100,
@@ -517,7 +517,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         // This will fail if implementation interprets local time as month-boundary
         #expect(items.map(\.content).contains("JSTBoundary"))
@@ -529,7 +529,7 @@ struct ItemPredicateTest {
 
         // Insert three items, one at start, one in middle, one at end of February (UTC)
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: shiftedDate("2024-02-01T00:00:00Z"),
              content: "StartOfMonth",
              income: 100,
@@ -538,7 +538,7 @@ struct ItemPredicateTest {
              repeatCount: 1)
         )
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: shiftedDate("2024-02-14T12:00:00Z"),
              content: "MidMonth",
              income: 100,
@@ -547,7 +547,7 @@ struct ItemPredicateTest {
              repeatCount: 1)
         )
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: shiftedDate("2024-02-29T23:59:59Z"),
              content: "EndOfMonth",
              income: 100,
@@ -557,7 +557,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-02-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("StartOfMonth"))
@@ -574,7 +574,7 @@ struct ItemPredicateTest {
         let jstDate2 = shiftedDate("2024-03-31T23:59:59Z")  // 2024-03-31T14:59:59Z
 
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate1,
              content: "StartJST",
              income: 100,
@@ -583,7 +583,7 @@ struct ItemPredicateTest {
              repeatCount: 1)
         )
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate2,
              content: "EndJST",
              income: 100,
@@ -593,7 +593,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameMonthAs(shiftedDate("2024-03-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents == ["EndJST", "StartJST"])
@@ -604,13 +604,13 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let baseDate = shiftedDate("2024-04-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: baseDate, content: "TargetDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-04-01T23:59:59Z"), content: "EndSameDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-03-31T23:59:59Z"), content: "DayBefore", income: 1, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-04-02T00:00:00Z"), content: "DayAfter", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: baseDate, content: "TargetDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-04-01T23:59:59Z"), content: "EndSameDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-03-31T23:59:59Z"), content: "DayBefore", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-04-02T00:00:00Z"), content: "DayAfter", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameDayAs(baseDate)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("TargetDay"))
@@ -628,7 +628,7 @@ struct ItemPredicateTest {
         let jstDate2 = shiftedDate("2024-04-01T23:59:59Z")  // 2024-04-01T15:00:00Z
 
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate1,
              content: "StartJSTDay",
              income: 100,
@@ -637,7 +637,7 @@ struct ItemPredicateTest {
              repeatCount: 1)
         )
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate2,
              content: "EndJSTDay",
              income: 100,
@@ -647,7 +647,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameDayAs(shiftedDate("2024-04-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents.contains("StartJSTDay"))
@@ -660,11 +660,11 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let baseDate = shiftedDate("2024-04-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-03-31T00:00:00Z"), content: "PrevDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-04-02T00:00:00Z"), content: "NextDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-03-31T00:00:00Z"), content: "PrevDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-04-02T00:00:00Z"), content: "NextDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameDayAs(baseDate)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(!contents.contains("PrevDay"))
@@ -678,10 +678,10 @@ struct ItemPredicateTest {
 
         let baseDate = shiftedDate("2024-04-01T00:00:00Z")
         let endOfDay = shiftedDate("2024-04-01T23:59:59Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: endOfDay, content: "EndOfDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: endOfDay, content: "EndOfDay", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameDayAs(baseDate)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents == ["EndOfDay"])
@@ -692,10 +692,10 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let baseDate = shiftedDate("2024-04-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-04-02T00:00:00Z"), content: "NextDayStart", income: 1, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-04-02T00:00:00Z"), content: "NextDayStart", income: 1, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.dateIsSameDayAs(baseDate)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         #expect(items.isEmpty)
     }
@@ -706,7 +706,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-01-01T00:00:00Z")
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JST_Jan1",
              income: 0,
@@ -716,7 +716,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameDayAs(shiftedDate("2024-01-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         #expect(items.map(\.content).contains("JST_Jan1"))
     }
@@ -727,7 +727,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-04-02T00:00:00Z") // UTC: 2024-04-01T15:00:00Z
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JST_NextDay",
              income: 0,
@@ -737,7 +737,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameDayAs(shiftedDate("2024-04-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         #expect(!items.map(\.content).contains("JST_NextDay"))
     }
@@ -748,7 +748,7 @@ struct ItemPredicateTest {
 
         let jstDate = shiftedDate("2024-04-01T00:00:00Z") // UTC: 2024-03-31T15:00:00Z
         _ = try CreateItemIntent.perform(
-            (container: context.container,
+            (container: container,
              date: jstDate,
              content: "JST_StartOfDay",
              income: 0,
@@ -758,7 +758,7 @@ struct ItemPredicateTest {
         )
 
         let predicate = ItemPredicate.dateIsSameDayAs(shiftedDate("2024-03-31T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
 
         #expect(!items.map(\.content).contains("JST_StartOfDay"))
     }
@@ -770,11 +770,11 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let date = shiftedDate("2024-06-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: date, content: "Match", income: 0, outgo: 5_000, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: date, content: "Low", income: 0, outgo: 4_999, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: date, content: "Match", income: 0, outgo: 5_000, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: date, content: "Low", income: 0, outgo: 4_999, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.outgoIsGreaterThanOrEqualTo(amount: 5_000, onOrAfter: date)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents == ["Match"])
@@ -785,11 +785,11 @@ struct ItemPredicateTest {
         NSTimeZone.default = timeZone
 
         let cutoffDate = shiftedDate("2024-06-01T00:00:00Z")
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-05-31T23:59:59Z"), content: "Early", income: 0, outgo: 10_000, category: "Test", repeatCount: 1))
-        _ = try CreateItemIntent.perform((container: context.container, date: cutoffDate, content: "Valid", income: 0, outgo: 10_000, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-05-31T23:59:59Z"), content: "Early", income: 0, outgo: 10_000, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: cutoffDate, content: "Valid", income: 0, outgo: 10_000, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.outgoIsGreaterThanOrEqualTo(amount: 5_000, onOrAfter: cutoffDate)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents == ["Valid"])
@@ -801,15 +801,15 @@ struct ItemPredicateTest {
     func includesItemsWithRepeatID(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-01-01T00:00:00Z"), content: "RepeatOne", income: 0, outgo: 0, category: "Test", repeatCount: 1))
-        let repeatOneItem = try context.fetch(.items(.all)).first {
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-01-01T00:00:00Z"), content: "RepeatOne", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        let repeatOneItem = try container.mainContext.fetch(.items(.all)).first {
             $0.content == "RepeatOne"
         }!
         let repeatID = repeatOneItem.repeatID
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-02-01T00:00:00Z"), content: "NonRepeat", income: 0, outgo: 0, category: "Test", repeatCount: 1))
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-02-01T00:00:00Z"), content: "NonRepeat", income: 0, outgo: 0, category: "Test", repeatCount: 1))
 
         let predicate = ItemPredicate.repeatIDIs(repeatID)
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents == ["RepeatOne"])
@@ -819,11 +819,11 @@ struct ItemPredicateTest {
     func includesOnlyFutureRepeatItems(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone
 
-        _ = try CreateItemIntent.perform((container: context.container, date: shiftedDate("2024-01-01T00:00:00Z"), content: "Past", income: 0, outgo: 0, category: "Test", repeatCount: 2))
-        let repeatID = try context.fetch(.items(.all)).first!.repeatID
+        _ = try CreateItemIntent.perform((container: container, date: shiftedDate("2024-01-01T00:00:00Z"), content: "Past", income: 0, outgo: 0, category: "Test", repeatCount: 2))
+        let repeatID = try container.mainContext.fetch(.items(.all)).first!.repeatID
 
         let predicate = ItemPredicate.repeatIDAndDateIsAfter(repeatID: repeatID, date: shiftedDate("2024-02-01T00:00:00Z"))
-        let items = try context.fetch(.items(predicate))
+        let items = try container.mainContext.fetch(.items(predicate))
         let contents = items.map(\.content)
 
         #expect(contents == ["Past"])

--- a/IncomesTests/TimeZone/ItemServiceTest.swift
+++ b/IncomesTests/TimeZone/ItemServiceTest.swift
@@ -14,10 +14,10 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ItemServiceTest {
-    let context: ModelContext
+    let container: ModelContainer
 
     init() {
-        context = testContext
+        container = testContainer
     }
 
     @discardableResult
@@ -29,7 +29,7 @@ struct ItemServiceTest {
                     repeatCount: Int = 1) throws -> ItemEntity {
         try CreateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 date: date,
                 content: content,
                 income: income,
@@ -53,7 +53,7 @@ struct ItemServiceTest {
             outgo: 50,
             category: "Test"
         )
-        let item = try #require(try context.fetchFirst(.items(.all)))
+        let item = try #require(try container.mainContext.fetchFirst(.items(.all)))
         #expect(item.content == "First")
     }
 
@@ -76,7 +76,7 @@ struct ItemServiceTest {
             category: "Transport"
         )
         let predicate = ItemPredicate.outgoIsGreaterThanOrEqualTo(amount: 400, onOrAfter: isoDate("2024-01-01T00:00:00Z"))
-        let item = try #require(try context.fetchFirst(.items(predicate)))
+        let item = try #require(try container.mainContext.fetchFirst(.items(predicate)))
         #expect(item.content == "Food")
     }
 
@@ -98,7 +98,7 @@ struct ItemServiceTest {
             outgo: 0,
             category: "Test"
         )
-        let items = try context.fetch(.items(.all))
+        let items = try container.mainContext.fetch(.items(.all))
         #expect(items.count == 2)
     }
 
@@ -121,7 +121,7 @@ struct ItemServiceTest {
             category: "Filtered"
         )
         let predicate = ItemPredicate.outgoIsGreaterThanOrEqualTo(amount: 500, onOrAfter: isoDate("2024-01-01T00:00:00Z"))
-        let filtered = try context.fetch(.items(predicate))
+        let filtered = try container.mainContext.fetch(.items(predicate))
         #expect(filtered.count == 1)
         #expect(filtered.first?.content == "Match")
     }
@@ -137,7 +137,7 @@ struct ItemServiceTest {
             outgo: 100,
             category: "Test"
         )
-        let count = try context.fetchCount(.items(.all))
+        let count = try container.mainContext.fetchCount(.items(.all))
         #expect(count == 1)
     }
 
@@ -160,7 +160,7 @@ struct ItemServiceTest {
             category: "Filtered"
         )
         let predicate = ItemPredicate.outgoIsGreaterThanOrEqualTo(amount: 800, onOrAfter: isoDate("2024-01-01T00:00:00Z"))
-        let count = try context.fetchCount(.items(predicate))
+        let count = try container.mainContext.fetchCount(.items(predicate))
         #expect(count == 1)
     }
 
@@ -177,7 +177,7 @@ struct ItemServiceTest {
             outgo: 300,
             category: "Food"
         )
-        let item = try #require(fetchItems(context).first)
+        let item = try #require(fetchItems(container).first)
         #expect(item.balance == 700)
     }
 
@@ -193,7 +193,7 @@ struct ItemServiceTest {
             category: "Housing",
             repeatCount: 3
         )
-        let items = fetchItems(context)
+        let items = fetchItems(container)
         #expect(items.count == 3)
         #expect(Set(items.map(\.repeatID)).count == 1)
     }
@@ -210,7 +210,7 @@ struct ItemServiceTest {
             category: "Solo",
             repeatCount: 0
         )
-        let items = fetchItems(context)
+        let items = fetchItems(container)
         #expect(items.count == 1)
         #expect(items.first?.content == "Single")
     }
@@ -226,7 +226,7 @@ struct ItemServiceTest {
             outgo: 0,
             category: "Empty"
         )
-        let item = try #require(fetchItems(context).first)
+        let item = try #require(fetchItems(container).first)
         #expect(item.balance == 0)
     }
 
@@ -243,7 +243,7 @@ struct ItemServiceTest {
                 category: "Shared"
             )
         }
-        let items = fetchItems(context)
+        let items = fetchItems(container)
         #expect(items.count == 2)
         #expect(Set(items.map(\.category?.name)).count == 1)
     }
@@ -260,7 +260,7 @@ struct ItemServiceTest {
             outgo: 0,
             category: "Test"
         )
-        let found = try #require(try context.fetchFirst(.items(.idIs(.init(base64Encoded: item.id)))))
+        let found = try #require(try container.mainContext.fetchFirst(.items(.idIs(.init(base64Encoded: item.id)))))
         #expect(found.utcDate == isoDate("2024-03-15T00:00:00Z"))
     }
 
@@ -276,7 +276,7 @@ struct ItemServiceTest {
             outgo: 0,
             category: "Test"
         )
-        let found = try #require(try context.fetchFirst(.items(.idIs(.init(base64Encoded: item.id)))))
+        let found = try #require(try container.mainContext.fetchFirst(.items(.idIs(.init(base64Encoded: item.id)))))
         #expect(found.utcDate == isoDate("2024-03-15T00:00:00Z"))
     }
 
@@ -293,7 +293,7 @@ struct ItemServiceTest {
             outgo: 0,
             category: "Test"
         )
-        let found = try #require(try context.fetchFirst(.items(.idIs(.init(base64Encoded: item.id)))))
+        let found = try #require(try container.mainContext.fetchFirst(.items(.idIs(.init(base64Encoded: item.id)))))
         #expect(found.utcDate == expectedDate)
     }
 
@@ -310,10 +310,10 @@ struct ItemServiceTest {
             outgo: 50,
             category: "Misc"
         )
-        var item = try #require(fetchItems(context).first)
+        var item = try #require(fetchItems(container).first)
         try UpdateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(item)!,
                 date: shiftedDate("2024-01-02T00:00:00Z"),
                 content: "Updated",
@@ -322,7 +322,7 @@ struct ItemServiceTest {
                 category: "UpdatedCat"
             )
         )
-        item = try #require(fetchItems(context).first)
+        item = try #require(fetchItems(container).first)
         #expect(item.balance == 50)
         #expect(item.content == "Updated")
         #expect(item.utcDate == isoDate("2024-01-02T00:00:00Z"))
@@ -339,12 +339,12 @@ struct ItemServiceTest {
             outgo: 0,
             category: "Original"
         )
-        let item = try #require(fetchItems(context).first)
+        let item = try #require(fetchItems(container).first)
         let oldRepeatID = item.repeatID
 
         try UpdateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(item)!,
                 date: item.utcDate,
                 content: "Changed",
@@ -353,7 +353,7 @@ struct ItemServiceTest {
                 category: "Updated"
             )
         )
-        let updated = try #require(fetchItems(context).first)
+        let updated = try #require(fetchItems(container).first)
         #expect(updated.repeatID != oldRepeatID)
     }
 
@@ -375,12 +375,12 @@ struct ItemServiceTest {
             outgo: 0,
             category: "SortTest"
         )
-        var items = try context.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
+        var items = try container.mainContext.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
         #expect(items[0].content == "First")
 
         try UpdateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(items[1])!,
                 date: isoDate("2023-12-31T00:00:00Z"),
                 content: items[1].content,
@@ -390,7 +390,7 @@ struct ItemServiceTest {
             )
         )
 
-        items = try context.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
+        items = try container.mainContext.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
         #expect(items[0].content == "Second")
     }
 
@@ -406,11 +406,11 @@ struct ItemServiceTest {
             category: "Media",
             repeatCount: 3
         )
-        let items = try context.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
+        let items = try container.mainContext.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
         let target = items[1] // middle item
         try UpdateFutureItemsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(target)!,
                 date: target.utcDate,
                 content: "UpdatedSub",
@@ -419,7 +419,7 @@ struct ItemServiceTest {
                 category: "Entertainment"
             )
         )
-        let result = try context.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
+        let result = try container.mainContext.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
         #expect(result[0].content == "Subscription")
         #expect(result[1].content == "UpdatedSub")
         #expect(result[2].content == "UpdatedSub")
@@ -439,12 +439,12 @@ struct ItemServiceTest {
             category: "Bills",
             repeatCount: 3
         )
-        let items = try context.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
+        let items = try container.mainContext.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
         let last = items[2]
 
         try UpdateFutureItemsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(last)!,
                 date: last.utcDate,
                 content: "Changed",
@@ -453,7 +453,7 @@ struct ItemServiceTest {
                 category: "BillsUpdated"
             )
         )
-        let result = try context.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
+        let result = try container.mainContext.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
         #expect(result[0].content == "Monthly")
         #expect(result[1].content == "Monthly")
         #expect(result[2].content == "Changed")
@@ -470,10 +470,10 @@ struct ItemServiceTest {
             outgo: 50,
             category: "OneTime"
         )
-        let item = try #require(fetchItems(context).first)
+        let item = try #require(fetchItems(container).first)
         try UpdateFutureItemsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(item)!,
                 date: item.utcDate,
                 content: "SoloUpdated",
@@ -482,7 +482,7 @@ struct ItemServiceTest {
                 category: "OneTimeUpdated"
             )
         )
-        let updated = try #require(fetchItems(context).first)
+        let updated = try #require(fetchItems(container).first)
         #expect(updated.content == "SoloUpdated")
         #expect(updated.income == 100)
     }
@@ -499,11 +499,11 @@ struct ItemServiceTest {
             category: "Health",
             repeatCount: 3
         )
-        _ = try context.fetch(.items(.all))
-        let target = try #require(try context.fetchFirst(.items(.idIs(.init(base64Encoded: item.id)))))
+        _ = try container.mainContext.fetch(.items(.all))
+        let target = try #require(try container.mainContext.fetchFirst(.items(.idIs(.init(base64Encoded: item.id)))))
         try UpdateAllItemsIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(target)!,
                 date: target.utcDate,
                 content: "Fitness",
@@ -512,7 +512,7 @@ struct ItemServiceTest {
                 category: "Wellness"
             )
         )
-        let updatedItems = try context.fetch(.items(.all))
+        let updatedItems = try container.mainContext.fetch(.items(.all))
         #expect(updatedItems.count == 3)
         for item in updatedItems {
             #expect(item.content == "Fitness")
@@ -534,14 +534,14 @@ struct ItemServiceTest {
             outgo: 0,
             category: "Temp"
         )
-        let item = try #require(fetchItems(context).first)
+        let item = try #require(fetchItems(container).first)
         try DeleteItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(item)!
             )
         )
-        let items = try context.fetch(.items(.all))
+        let items = try container.mainContext.fetch(.items(.all))
         #expect(items.isEmpty)
     }
 
@@ -563,13 +563,13 @@ struct ItemServiceTest {
             outgo: 0,
             category: "General"
         )
-        let allItems = try context.fetch(.items(.all))
+        let allItems = try container.mainContext.fetch(.items(.all))
         let toDelete = allItems.filter { $0.content == "RemoveMe" }
         try toDelete.forEach {
-            try DeleteItemIntent.perform((container: context.container, item: ItemEntity($0)!))
+            try DeleteItemIntent.perform((container: container, item: ItemEntity($0)!))
         }
 
-        let remaining = try context.fetch(.items(.all))
+        let remaining = try container.mainContext.fetch(.items(.all))
         #expect(remaining.count == 1)
         #expect(remaining.first?.content == "KeepMe")
     }
@@ -585,9 +585,9 @@ struct ItemServiceTest {
             outgo: 100,
             category: "Tmp"
         )
-        #expect(!fetchItems(context).isEmpty)
-        try DeleteAllItemsIntent.perform(context.container)
-        #expect(fetchItems(context).isEmpty)
+        #expect(!fetchItems(container).isEmpty)
+        try DeleteAllItemsIntent.perform(container)
+        #expect(fetchItems(container).isEmpty)
     }
 
     // MARK: - Calculate balance
@@ -603,10 +603,10 @@ struct ItemServiceTest {
             outgo: 50,
             category: "Test"
         )
-        var item = try #require(fetchItems(context).first)
+        var item = try #require(fetchItems(container).first)
         try UpdateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(item)!,
                 date: item.utcDate,
                 content: item.content,
@@ -615,7 +615,7 @@ struct ItemServiceTest {
                 category: item.category?.name ?? ""
             )
         )
-        item = try #require(fetchItems(context).first)
+        item = try #require(fetchItems(container).first)
         #expect(item.balance == 10)
     }
 
@@ -630,14 +630,14 @@ struct ItemServiceTest {
             outgo: 60,
             category: "Check"
         )
-        let item = try #require(fetchItems(context).first)
+        let item = try #require(fetchItems(container).first)
         let oldBalance = item.balance
 
         try RecalculateItemIntent.perform(
-            (container: context.container, date: isoDate("2023-12-01T00:00:00Z"))
+            (container: container, date: isoDate("2023-12-01T00:00:00Z"))
         )
 
-        let reloaded = try #require(fetchItems(context).first)
+        let reloaded = try #require(fetchItems(container).first)
         #expect(reloaded.balance == oldBalance)
     }
 
@@ -659,10 +659,10 @@ struct ItemServiceTest {
             outgo: 80,
             category: "Split"
         )
-        var items = try context.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
+        var items = try container.mainContext.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
         try UpdateItemIntent.perform(
             (
-                container: context.container,
+                container: container,
                 item: ItemEntity(items[1])!,
                 date: items[1].utcDate,
                 content: items[1].content,
@@ -673,9 +673,9 @@ struct ItemServiceTest {
         )
 
         try RecalculateItemIntent.perform(
-            (container: context.container, date: isoDate("2024-01-15T00:00:00Z"))
+            (container: container, date: isoDate("2024-01-15T00:00:00Z"))
         )
-        items = try context.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
+        items = try container.mainContext.fetch(.items(.all)).sorted { $0.utcDate < $1.utcDate }
         #expect(items[0].balance == 50)
         #expect(items[1].balance == 470)
     }
@@ -700,9 +700,9 @@ struct ItemServiceTest {
         )
 
         try RecalculateItemIntent.perform(
-            (container: context.container, date: isoDate("2024-02-01T00:00:00Z"))
+            (container: container, date: isoDate("2024-02-01T00:00:00Z"))
         )
-        let items = try context.fetch(.items(.all))
+        let items = try container.mainContext.fetch(.items(.all))
 
         #expect(items[0].content == "LateFeb")
         #expect(items[0].balance == 650)

--- a/IncomesTests/TimeZone/ItemTest.swift
+++ b/IncomesTests/TimeZone/ItemTest.swift
@@ -10,6 +10,7 @@ import Foundation
 @testable import Incomes
 import Testing
 
+@MainActor
 @Suite(.serialized)
 struct ItemTest {
     let container = testContainer

--- a/IncomesTests/TimeZone/ItemTest.swift
+++ b/IncomesTests/TimeZone/ItemTest.swift
@@ -12,7 +12,7 @@ import Testing
 
 @Suite(.serialized)
 struct ItemTest {
-    let context = testContext
+    let container = testContainer
 
     init() {
         NSTimeZone.default = .current
@@ -32,7 +32,7 @@ struct ItemTest {
         let repeatID = UUID()
 
         let item = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: date,
             content: content,
             income: income,
@@ -66,7 +66,7 @@ struct ItemTest {
         NSTimeZone.default = .init(identifier: "Asia/Tokyo")!
 
         let item = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: date,
             content: "Check",
             income: .zero,
@@ -82,7 +82,7 @@ struct ItemTest {
     func createAssignsDefaultValues() throws {
         let date = shiftedDate("2024-01-01T00:00:00Z")
         let item = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: date,
             content: "",
             income: .zero,
@@ -104,7 +104,7 @@ struct ItemTest {
 
         let date = shiftedDate("2024-06-10T12:00:00Z")
         let item = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: date,
             content: "Groceries",
             income: .zero,
@@ -125,7 +125,7 @@ struct ItemTest {
     @Test("modify updates values and regenerates tags with UTC-normalized date")
     func modifyUpdatesValuesAndRegeneratesTags() throws {
         let item = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: shiftedDate("2024-01-01T00:00:00Z"),
             content: "Old",
             income: 100,
@@ -168,7 +168,7 @@ struct ItemTest {
         NSTimeZone.default = .init(identifier: "Asia/Tokyo")!
 
         let item = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: shiftedDate("2024-01-01T00:00:00Z"),
             content: "Initial",
             income: 0,
@@ -195,7 +195,7 @@ struct ItemTest {
 
         let repeatID = UUID()
         let item = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: shiftedDate("2024-02-01T00:00:00Z"),
             content: "Init",
             income: 0,
@@ -222,7 +222,7 @@ struct ItemTest {
         NSTimeZone.default = timeZone
 
         let item = try Item.create(
-            context: context,
+            context: container.mainContext,
             date: shiftedDate("2024-07-01T10:00:00Z"),
             content: "Init",
             income: 0,


### PR DESCRIPTION
## Summary
- add `testContainer` computed property
- update test initializers to use `ModelContainer`
- change `fetchItems` helper to accept a container
- replace direct `ModelContext` usage with `container.mainContext`

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y swiftlint` *(fails: Unable to locate package swiftlint)*

------
https://chatgpt.com/codex/tasks/task_e_6865ce30a3608320a4d110183cd57577