### PR TITLE
Update create helpers to use ModelContainer

### DIFF
--- a/Incomes/Sources/Common/Views/IntroductionView.swift
+++ b/Incomes/Sources/Common/Views/IntroductionView.swift
@@ -46,7 +46,7 @@ struct IntroductionView: View {
                         withAnimation {
                             isLoading = true
                         }
-                        await IncomesPreviewStore().prepare(context)
+                        await IncomesPreviewStore().prepare(context.container)
                         try? await Task.sleep(for: .seconds(5))
                         withAnimation {
                             isLoading = false

--- a/Incomes/Sources/Debug/Models/IncomesPreview.swift
+++ b/Incomes/Sources/Debug/Models/IncomesPreview.swift
@@ -45,8 +45,7 @@ struct IncomesPreview<Content: View>: View {
             } else {
                 ProgressView()
                     .task {
-                        let context = previewModelContainer.mainContext
-                        await preview.prepare(context)
+                        await preview.prepare(previewModelContainer)
                         isReady = true
                     }
             }

--- a/Incomes/Sources/Debug/Models/IncomesPreviewStore.swift
+++ b/Incomes/Sources/Debug/Models/IncomesPreviewStore.swift
@@ -9,6 +9,7 @@
 import SwiftData
 import SwiftUI
 
+@MainActor
 @Observable
 final class IncomesPreviewStore {
     private(set) var items = [Item]()
@@ -18,7 +19,6 @@ final class IncomesPreviewStore {
         items.isNotEmpty && tags.isNotEmpty
     }
 
-    @MainActor
     func prepare(_ container: ModelContainer) async {
         createItems(container)
         while !isReady {
@@ -29,7 +29,6 @@ final class IncomesPreviewStore {
         try! BalanceCalculator().calculate(in: container.mainContext, for: items)
     }
 
-    @MainActor
     func prepareIgnoringDuplicates(_ container: ModelContainer) {
         for index in 0..<24 {
             _ = try! Item.createIgnoringDuplicates(

--- a/Incomes/Sources/Debug/Models/IncomesPreviewStore.swift
+++ b/Incomes/Sources/Debug/Models/IncomesPreviewStore.swift
@@ -19,21 +19,21 @@ final class IncomesPreviewStore {
     }
 
     @MainActor
-    func prepare(_ context: ModelContext) async {
-        createItems(context)
+    func prepare(_ container: ModelContainer) async {
+        createItems(container)
         while !isReady {
             try! await Task.sleep(for: .seconds(0.2))
-            items = try! context.fetch(.items(.all))
-            tags = try! context.fetch(.tags(.all))
+            items = try! container.mainContext.fetch(.items(.all))
+            tags = try! container.mainContext.fetch(.tags(.all))
         }
-        try! BalanceCalculator().calculate(in: context, for: items)
+        try! BalanceCalculator().calculate(in: container.mainContext, for: items)
     }
 
     @MainActor
-    func prepareIgnoringDuplicates(_ context: ModelContext) {
+    func prepareIgnoringDuplicates(_ container: ModelContainer) {
         for index in 0..<24 {
             _ = try! Item.createIgnoringDuplicates(
-                context: context,
+                container: container,
                 date: Calendar.current.date(
                     byAdding: .month,
                     value: index,
@@ -46,10 +46,10 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
         }
-        try! BalanceCalculator().calculate(in: context, for: items)
+        try! BalanceCalculator().calculate(in: container.mainContext, for: items)
     }
 
-    private func createItems(_ context: ModelContext) {
+    private func createItems(_ container: ModelContainer) {
         let now = Calendar.current.startOfYear(for: .now)
 
         let dateA = Calendar.current.date(byAdding: .day, value: 0, to: now)!
@@ -63,7 +63,7 @@ final class IncomesPreviewStore {
         }
 
         _ = try! Item.create(
-            context: context,
+            container: container,
             date: date(-1, dateD),
             content: String(localized: "Payday"),
             income: LocaleAmountConverter.localizedAmount(baseUSD: 4_500),
@@ -74,7 +74,7 @@ final class IncomesPreviewStore {
 
         for index in 0..<24 {
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateD),
                 content: String(localized: "Payday"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 4_500),
@@ -83,7 +83,7 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateD),
                 content: String(localized: "Advertising revenue"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 500),
@@ -92,7 +92,7 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateB),
                 content: String(localized: "Apple card"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 0),
@@ -101,7 +101,7 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateA),
                 content: String(localized: "Orange card"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 0),
@@ -110,7 +110,7 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateD),
                 content: String(localized: "Lemon card"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 0),
@@ -119,7 +119,7 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateE),
                 content: String(localized: "House"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 0),
@@ -128,7 +128,7 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateC),
                 content: String(localized: "Car"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 0),
@@ -137,7 +137,7 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateA),
                 content: String(localized: "Insurance"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 0),
@@ -146,7 +146,7 @@ final class IncomesPreviewStore {
                 repeatID: .init()
             )
             _ = try! Item.create(
-                context: context,
+                container: container,
                 date: date(index, dateE),
                 content: String(localized: "Pension"),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 0),

--- a/Incomes/Sources/Debug/Views/DebugListView.swift
+++ b/Incomes/Sources/Debug/Views/DebugListView.swift
@@ -65,13 +65,13 @@ extension DebugListView: View {
         ) {
             Button(role: .destructive) {
                 Task {
-                    await IncomesPreviewStore().prepare(context)
+                    await IncomesPreviewStore().prepare(context.container)
                 }
             } label: {
                 Text("Prepare")
             }
             Button(role: .destructive) {
-                IncomesPreviewStore().prepareIgnoringDuplicates(context)
+                IncomesPreviewStore().prepareIgnoringDuplicates(context.container)
             } label: {
                 Text("Prepare ignoring duplicates")
             }

--- a/Incomes/Sources/Item/Intents/Create/CreateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Create/CreateItemIntent.swift
@@ -35,13 +35,12 @@ struct CreateItemIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, date, content, income, outgo, category, repeatCount) = input
-        let context = container.mainContext
         var items = [Item]()
 
         let repeatID = UUID()
 
         let model = try Item.create(
-            context: context,
+            container: container,
             date: date,
             content: content,
             income: income,
@@ -62,7 +61,7 @@ struct CreateItemIntent: AppIntent, IntentPerformer {
                 continue
             }
             let item = try Item.create(
-                context: context,
+                container: container,
                 date: repeatingDate,
                 content: content,
                 income: income,
@@ -73,10 +72,10 @@ struct CreateItemIntent: AppIntent, IntentPerformer {
             items.append(item)
         }
 
-        items.forEach(context.insert)
+        items.forEach(container.mainContext.insert)
 
         let calculator = BalanceCalculator()
-        try calculator.calculate(in: context, for: items)
+        try calculator.calculate(in: container.mainContext, for: items)
 
         guard let entity = ItemEntity(model) else {
             throw ItemError.entityConversionFailed

--- a/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
@@ -12,13 +12,12 @@ struct DeleteAllItemsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     static func perform(_ input: Input) throws -> Output {
-        let context = input.mainContext
-        let items = try context.fetch(FetchDescriptor<Item>())
-        items.forEach {
-            $0.delete()
+        let items = try input.mainContext.fetch(FetchDescriptor<Item>())
+        items.forEach { item in
+            item.delete()
         }
         let calculator = BalanceCalculator()
-        try calculator.calculate(in: context, for: items)
+        try calculator.calculate(in: input.mainContext, for: items)
     }
 
     @MainActor

--- a/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
@@ -16,16 +16,17 @@ struct DeleteItemIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entity) = input
-        let context = container.mainContext
         guard
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
-            let model = try context.fetchFirst(.items(.idIs(id)))
+            let model = try container.mainContext.fetchFirst(
+                .items(.idIs(id))
+            )
         else {
             throw ItemError.itemNotFound
         }
         model.delete()
         let calculator = BalanceCalculator()
-        try calculator.calculate(in: context, for: [model])
+        try calculator.calculate(in: container.mainContext, for: [model])
     }
 
     @MainActor

--- a/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
@@ -27,10 +27,11 @@ struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entity, date, content, income, outgo, category) = input
-        let context = container.mainContext
         guard
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
-            let model = try context.fetchFirst(.items(.idIs(id)))
+            let model = try container.mainContext.fetchFirst(
+                .items(.idIs(id))
+            )
         else {
             throw DebugError.default
         }

--- a/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
@@ -27,10 +27,11 @@ struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entity, date, content, income, outgo, category) = input
-        let context = container.mainContext
         guard
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
-            let model = try context.fetchFirst(.items(.idIs(id)))
+            let model = try container.mainContext.fetchFirst(
+                .items(.idIs(id))
+            )
         else {
             throw DebugError.default
         }

--- a/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
@@ -27,10 +27,11 @@ struct UpdateItemIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entity, date, content, income, outgo, category) = input
-        let context = container.mainContext
         guard
             let id = try? PersistentIdentifier(base64Encoded: entity.id),
-            let model = try context.fetchFirst(.items(.idIs(id)))
+            let model = try container.mainContext.fetchFirst(
+                .items(.idIs(id))
+            )
         else {
             throw DebugError.default
         }
@@ -43,7 +44,7 @@ struct UpdateItemIntent: AppIntent, IntentPerformer {
             repeatID: .init()
         )
         let calculator = BalanceCalculator()
-        try calculator.calculate(in: context, for: [model])
+        try calculator.calculate(in: container.mainContext, for: [model])
     }
 
     @MainActor

--- a/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
@@ -44,7 +44,7 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
         let repeatID = UUID()
         let items = try container.mainContext.fetch(descriptor)
         try items.forEach { item in
-            guard let newDate = Calendar.current.date(byAdding: components, to: $0.localDate) else {
+            guard let newDate = Calendar.current.date(byAdding: components, to: item.localDate) else {
                 assertionFailure()
                 return
             }

--- a/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
@@ -36,20 +36,19 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entity, date, content, income, outgo, category, descriptor) = input
-        let context = container.mainContext
         let components = Calendar.current.dateComponents(
             [.year, .month, .day],
             from: entity.date,
             to: date
         )
         let repeatID = UUID()
-        let items = try context.fetch(descriptor)
-        try items.forEach {
+        let items = try container.mainContext.fetch(descriptor)
+        try items.forEach { item in
             guard let newDate = Calendar.current.date(byAdding: components, to: $0.localDate) else {
                 assertionFailure()
                 return
             }
-            try $0.modify(
+            try item.modify(
                 date: newDate,
                 content: content,
                 income: income,
@@ -59,7 +58,7 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
             )
         }
         let calculator = BalanceCalculator()
-        try calculator.calculate(in: context, for: items)
+        try calculator.calculate(in: container.mainContext, for: items)
     }
 
     @MainActor

--- a/Incomes/Sources/Item/Models/Item.swift
+++ b/Incomes/Sources/Item/Models/Item.swift
@@ -23,7 +23,7 @@ final class Item {
 
     private init() {}
 
-    static func create(context: ModelContext,
+    static func create(container: ModelContainer,
                        date: Date,
                        content: String,
                        income: Decimal,
@@ -31,7 +31,7 @@ final class Item {
                        category: String,
                        repeatID: UUID) throws -> Item {
         let item = Item()
-        context.insert(item)
+        container.mainContext.insert(item)
 
         item.date = Calendar.utc.startOfDay(for: Calendar.utc.shiftedDate(componentsFrom: date, in: .current))
         item.content = content
@@ -41,22 +41,22 @@ final class Item {
 
         item.tags = [
             try .create(
-                context: context,
+                container: container,
                 name: date.stringValueWithoutLocale(.yyyy),
                 type: .year
             ),
             try .create(
-                context: context,
+                container: container,
                 name: date.stringValueWithoutLocale(.yyyyMM),
                 type: .yearMonth
             ),
             try .create(
-                context: context,
+                container: container,
                 name: content,
                 type: .content
             ),
             try .create(
-                context: context,
+                container: container,
                 name: category,
                 type: .category
             )
@@ -83,22 +83,22 @@ final class Item {
 
         self.tags = [
             try .create(
-                context: context,
+                container: context.container,
                 name: date.stringValueWithoutLocale(.yyyy),
                 type: .year
             ),
             try .create(
-                context: context,
+                container: context.container,
                 name: date.stringValueWithoutLocale(.yyyyMM),
                 type: .yearMonth
             ),
             try .create(
-                context: context,
+                container: context.container,
                 name: content,
                 type: .content
             ),
             try .create(
-                context: context,
+                container: context.container,
                 name: category,
                 type: .category
             )
@@ -153,7 +153,7 @@ extension Item: Comparable {
 // MARK: - Test
 
 extension Item {
-    static func createIgnoringDuplicates(context: ModelContext,
+    static func createIgnoringDuplicates(container: ModelContainer,
                                          date: Date,
                                          content: String,
                                          income: Decimal,
@@ -161,7 +161,7 @@ extension Item {
                                          category: String,
                                          repeatID: UUID) throws -> Item {
         let item = Item()
-        context.insert(item)
+        container.mainContext.insert(item)
 
         item.date = Calendar.utc.startOfDay(for: Calendar.utc.shiftedDate(componentsFrom: date, in: .current))
         item.content = content
@@ -171,22 +171,22 @@ extension Item {
 
         item.tags = [
             try .createIgnoringDuplicates(
-                context: context,
+                container: container,
                 name: date.stringValueWithoutLocale(.yyyy),
                 type: .year
             ),
             try .createIgnoringDuplicates(
-                context: context,
+                container: container,
                 name: date.stringValueWithoutLocale(.yyyyMM),
                 type: .yearMonth
             ),
             try .createIgnoringDuplicates(
-                context: context,
+                container: container,
                 name: content,
                 type: .content
             ),
             try .createIgnoringDuplicates(
-                context: context,
+                container: container,
                 name: category,
                 type: .category
             )

--- a/Incomes/Sources/Item/Models/Item.swift
+++ b/Incomes/Sources/Item/Models/Item.swift
@@ -23,6 +23,7 @@ final class Item {
 
     private init() {}
 
+    @MainActor
     static func create(container: ModelContainer,
                        date: Date,
                        content: String,
@@ -65,6 +66,7 @@ final class Item {
         return item
     }
 
+    @MainActor
     func modify(date: Date,
                 content: String,
                 income: Decimal,
@@ -153,6 +155,7 @@ extension Item: Comparable {
 // MARK: - Test
 
 extension Item {
+    @MainActor
     static func createIgnoringDuplicates(container: ModelContainer,
                                          date: Date,
                                          content: String,

--- a/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
@@ -12,10 +12,9 @@ struct DeleteAllTagsIntent: AppIntent, IntentPerformer {
 
     @MainActor
     static func perform(_ input: Input) throws -> Output {
-        let context = input.mainContext
-        let tags = try context.fetch(FetchDescriptor<Tag>())
-        tags.forEach {
-            $0.delete()
+        let tags = try input.mainContext.fetch(FetchDescriptor<Tag>())
+        tags.forEach { tag in
+            tag.delete()
         }
     }
 

--- a/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
@@ -16,9 +16,10 @@ struct DeleteTagIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entity) = input
-        let context = container.mainContext
         let id = try PersistentIdentifier(base64Encoded: entity.id)
-        guard let model = try context.fetchFirst(.tags(.idIs(id))) else {
+        guard let model = try container.mainContext.fetchFirst(
+            .tags(.idIs(id))
+        ) else {
             throw TagError.tagNotFound
         }
         model.delete()

--- a/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
@@ -16,10 +16,11 @@ struct FindDuplicateTagsIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entities) = input
-        let context = container.mainContext
         let models: [Tag] = try entities.compactMap { entity in
             let id = try PersistentIdentifier(base64Encoded: entity.id)
-            return try context.fetchFirst(.tags(.idIs(id)))
+            return try container.mainContext.fetchFirst(
+                .tags(.idIs(id))
+            )
         }
         let duplicates = Dictionary(grouping: models) { tag in
             tag.typeID + tag.name

--- a/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
@@ -16,10 +16,11 @@ struct MergeDuplicateTagsIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entities) = input
-        let context = container.mainContext
         let models: [Tag] = try entities.compactMap { entity in
             let id = try PersistentIdentifier(base64Encoded: entity.id)
-            return try context.fetchFirst(.tags(.idIs(id)))
+            return try container.mainContext.fetchFirst(
+                .tags(.idIs(id))
+            )
         }
         guard let parent = models.first else {
             return

--- a/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
@@ -16,13 +16,16 @@ struct ResolveDuplicateTagsIntent: AppIntent, IntentPerformer {
     @MainActor
     static func perform(_ input: Input) throws -> Output {
         let (container, entities) = input
-        let context = container.mainContext
         let models: [Tag] = try entities.compactMap { entity in
             let id = try PersistentIdentifier(base64Encoded: entity.id)
-            return try context.fetchFirst(.tags(.idIs(id)))
+            return try container.mainContext.fetchFirst(
+                .tags(.idIs(id))
+            )
         }
         for model in models {
-            let duplicates = try context.fetch(.tags(.isSameWith(model)))
+            let duplicates = try container.mainContext.fetch(
+                .tags(.isSameWith(model))
+            )
             try MergeDuplicateTagsIntent.perform(
                 (
                     container: container,

--- a/Incomes/Sources/Tag/Models/Tag.swift
+++ b/Incomes/Sources/Tag/Models/Tag.swift
@@ -18,6 +18,7 @@ final class Tag {
 
     private init() {}
 
+    @MainActor
     static func create(container: ModelContainer, name: String, type: TagType) throws -> Tag {
         let tag = try container.mainContext.fetchFirst(
             .tags(.nameIs(name, type: type))
@@ -55,6 +56,7 @@ extension Tag: Identifiable {}
 // MARK: - Test
 
 extension Tag {
+    @MainActor
     static func createIgnoringDuplicates(container: ModelContainer, name: String, type: TagType) throws -> Tag {
         let tag = Tag()
         container.mainContext.insert(tag)

--- a/Incomes/Sources/Tag/Models/Tag.swift
+++ b/Incomes/Sources/Tag/Models/Tag.swift
@@ -18,9 +18,11 @@ final class Tag {
 
     private init() {}
 
-    static func create(context: ModelContext, name: String, type: TagType) throws -> Tag {
-        let tag = try context.fetchFirst(.tags(.nameIs(name, type: type))) ?? .init()
-        context.insert(tag)
+    static func create(container: ModelContainer, name: String, type: TagType) throws -> Tag {
+        let tag = try container.mainContext.fetchFirst(
+            .tags(.nameIs(name, type: type))
+        ) ?? .init()
+        container.mainContext.insert(tag)
         tag.name = name
         tag.typeID = type.rawValue
         return tag
@@ -53,9 +55,9 @@ extension Tag: Identifiable {}
 // MARK: - Test
 
 extension Tag {
-    static func createIgnoringDuplicates(context: ModelContext, name: String, type: TagType) throws -> Tag {
+    static func createIgnoringDuplicates(container: ModelContainer, name: String, type: TagType) throws -> Tag {
         let tag = Tag()
-        context.insert(tag)
+        container.mainContext.insert(tag)
         tag.name = name
         tag.typeID = type.rawValue
         return tag

--- a/IncomesTests/Default/BalanceCalculatorTests.swift
+++ b/IncomesTests/Default/BalanceCalculatorTests.swift
@@ -16,7 +16,7 @@ final class BalanceCalculatorTests: XCTestCase {
             let calculator = BalanceCalculator()
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -27,7 +27,7 @@ final class BalanceCalculatorTests: XCTestCase {
             }
             try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
-            let item = try! Item.create(context: container.mainContext,
+            let item = try! Item.create(container: container,
                                         date: shiftedDate("2000-01-31T12:00:00Z"),
                                         content: "content",
                                         income: 200,
@@ -49,7 +49,7 @@ final class BalanceCalculatorTests: XCTestCase {
             let calculator = BalanceCalculator()
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -60,7 +60,7 @@ final class BalanceCalculatorTests: XCTestCase {
             }
             try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
-            let item = try! Item.create(context: container.mainContext,
+            let item = try! Item.create(container: container,
                                         date: shiftedDate("2001-01-01T00:00:00Z"),
                                         content: "content",
                                         income: 200,
@@ -82,7 +82,7 @@ final class BalanceCalculatorTests: XCTestCase {
             let calculator = BalanceCalculator()
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -93,7 +93,7 @@ final class BalanceCalculatorTests: XCTestCase {
             }
             try! calculator.calculate(in: container.mainContext, after: .distantPast)
 
-            let item = try! Item.create(context: container.mainContext,
+            let item = try! Item.create(container: container,
                                         date: shiftedDate("2000-01-01T00:00:00Z"),
                                         content: "content",
                                         income: 200,
@@ -117,7 +117,7 @@ final class BalanceCalculatorTests: XCTestCase {
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -152,7 +152,7 @@ final class BalanceCalculatorTests: XCTestCase {
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -187,7 +187,7 @@ final class BalanceCalculatorTests: XCTestCase {
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -222,7 +222,7 @@ final class BalanceCalculatorTests: XCTestCase {
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -257,7 +257,7 @@ final class BalanceCalculatorTests: XCTestCase {
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -287,7 +287,7 @@ final class BalanceCalculatorTests: XCTestCase {
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,
@@ -317,7 +317,7 @@ final class BalanceCalculatorTests: XCTestCase {
             var items: [Item] = []
 
             for i in 1...5 {
-                let item = try! Item.create(context: container.mainContext,
+                let item = try! Item.create(container: container,
                                             date: shiftedDate("2000-0\(i)-01T12:00:00Z"),
                                             content: "content",
                                             income: 200,

--- a/IncomesTests/Default/Intent/DeleteTagIntentTest.swift
+++ b/IncomesTests/Default/Intent/DeleteTagIntentTest.swift
@@ -11,7 +11,7 @@ struct DeleteTagIntentTest {
     }
 
     @Test func perform() throws {
-        let tag = try Tag.create(context: container.mainContext, name: "name", type: .year)
+        let tag = try Tag.create(container: container, name: "name", type: .year)
         #expect(try container.mainContext.fetchCount(.tags(.all)) == 1)
         try DeleteTagIntent.perform((container: container, tag: .init(tag)!))
         #expect(try container.mainContext.fetchCount(.tags(.all)) == 0)

--- a/IncomesTests/Default/Intent/FindDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/FindDuplicateTagsIntentTest.swift
@@ -11,10 +11,10 @@ struct FindDuplicateTagsIntentTest {
     }
 
     @Test func perform() throws {
-        let tag1 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
-        let tag2 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
-        let tag3 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "B", type: .yearMonth)
-        let tag4 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "B", type: .yearMonth)
+        let tag1 = try Tag.createIgnoringDuplicates(container: container, name: "A", type: .year)
+        let tag2 = try Tag.createIgnoringDuplicates(container: container, name: "A", type: .year)
+        let tag3 = try Tag.createIgnoringDuplicates(container: container, name: "B", type: .yearMonth)
+        let tag4 = try Tag.createIgnoringDuplicates(container: container, name: "B", type: .yearMonth)
 
         let result = try FindDuplicateTagsIntent.perform(
             (

--- a/IncomesTests/Default/Intent/GetAllTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetAllTagsIntentTest.swift
@@ -11,8 +11,8 @@ struct GetAllTagsIntentTest {
     }
 
     @Test func perform() throws {
-        _ = try Tag.create(context: container.mainContext, name: "A", type: .year)
-        _ = try Tag.create(context: container.mainContext, name: "B", type: .content)
+        _ = try Tag.create(container: container, name: "A", type: .year)
+        _ = try Tag.create(container: container, name: "B", type: .content)
         let tags = try GetAllTagsIntent.perform(container)
         #expect(tags.count == 2)
     }

--- a/IncomesTests/Default/Intent/GetHasDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetHasDuplicateTagsIntentTest.swift
@@ -13,8 +13,8 @@ struct GetHasDuplicateTagsIntentTest {
     @Test func perform() throws {
         #expect(try GetHasDuplicateTagsIntent.perform(container) == false)
 
-        let tag1 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
-        _ = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
+        let tag1 = try Tag.createIgnoringDuplicates(container: container, name: "A", type: .year)
+        _ = try Tag.createIgnoringDuplicates(container: container, name: "A", type: .year)
 
         #expect(try GetHasDuplicateTagsIntent.perform(container) == true)
 

--- a/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetTagByIDIntentTest.swift
@@ -11,7 +11,7 @@ struct GetTagByIDIntentTest {
     }
 
     @Test func perform() throws {
-        let model = try Tag.create(context: container.mainContext, name: "name", type: .content)
+        let model = try Tag.create(container: container, name: "name", type: .content)
         let id = try model.id.base64Encoded()
         let tagEntity = try #require(
             try GetTagByIDIntent.perform(

--- a/IncomesTests/Default/Intent/GetTagByNameIntentTest.swift
+++ b/IncomesTests/Default/Intent/GetTagByNameIntentTest.swift
@@ -11,7 +11,7 @@ struct GetTagByNameIntentTest {
     }
 
     @Test func perform() throws {
-        _ = try Tag.create(context: container.mainContext, name: "name", type: .year)
+        _ = try Tag.create(container: container, name: "name", type: .year)
         let tag = try #require(
             try GetTagByNameIntent.perform(
                 (

--- a/IncomesTests/Default/Intent/MergeDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/MergeDuplicateTagsIntentTest.swift
@@ -12,7 +12,7 @@ struct MergeDuplicateTagsIntentTest {
 
     @Test func mergeWhenTagsAreDifferent() throws {
         let item1 = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: .now,
             content: "contentA",
             income: .zero,
@@ -21,7 +21,7 @@ struct MergeDuplicateTagsIntentTest {
             repeatID: .init()
         )
         let item2 = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: .now,
             content: "contentB",
             income: .zero,
@@ -30,7 +30,7 @@ struct MergeDuplicateTagsIntentTest {
             repeatID: .init()
         )
         let item3 = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: .now,
             content: "contentC",
             income: .zero,
@@ -64,9 +64,9 @@ struct MergeDuplicateTagsIntentTest {
     }
 
     @Test func mergeWhenTagsAreDuplicated() throws {
-        let tag1 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "contentA", type: .content)
-        let tag2 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "contentA", type: .content)
-        let tag3 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "contentA", type: .content)
+        let tag1 = try Tag.createIgnoringDuplicates(container: container, name: "contentA", type: .content)
+        let tag2 = try Tag.createIgnoringDuplicates(container: container, name: "contentA", type: .content)
+        let tag3 = try Tag.createIgnoringDuplicates(container: container, name: "contentA", type: .content)
 
         try MergeDuplicateTagsIntent.perform(
             (

--- a/IncomesTests/Default/Intent/ResolveDuplicateTagsIntentTest.swift
+++ b/IncomesTests/Default/Intent/ResolveDuplicateTagsIntentTest.swift
@@ -11,11 +11,11 @@ struct ResolveDuplicateTagsIntentTest {
     }
 
     @Test func perform() throws {
-        let tag1 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
-        _ = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
-        _ = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "A", type: .year)
-        let tag4 = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "B", type: .yearMonth)
-        _ = try Tag.createIgnoringDuplicates(context: container.mainContext, name: "B", type: .yearMonth)
+        let tag1 = try Tag.createIgnoringDuplicates(container: container, name: "A", type: .year)
+        _ = try Tag.createIgnoringDuplicates(container: container, name: "A", type: .year)
+        _ = try Tag.createIgnoringDuplicates(container: container, name: "A", type: .year)
+        let tag4 = try Tag.createIgnoringDuplicates(container: container, name: "B", type: .yearMonth)
+        _ = try Tag.createIgnoringDuplicates(container: container, name: "B", type: .yearMonth)
 
         #expect(try container.mainContext.fetchCount(.tags(.all)) == 5)
 

--- a/IncomesTests/TimeZone/ItemPredicateTest.swift
+++ b/IncomesTests/TimeZone/ItemPredicateTest.swift
@@ -61,7 +61,7 @@ struct ItemPredicateTest {
         let date = shiftedDate("2024-01-01T00:00:00Z")
         _ = try CreateItemIntent.perform((container: container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
-        let tag = try Tag.create(context: container.mainContext, name: "2024", type: .year)
+        let tag = try Tag.create(container: container, name: "2024", type: .year)
         let predicate = ItemPredicate.tagIs(tag)
         let items = try container.mainContext.fetch(.items(predicate))
 
@@ -95,7 +95,7 @@ struct ItemPredicateTest {
         let date = shiftedDate("2024-01-01T00:00:00Z")
         _ = try CreateItemIntent.perform((container: container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
-        let tag = try Tag.create(context: container.mainContext, name: "202401", type: .yearMonth)
+        let tag = try Tag.create(container: container, name: "202401", type: .yearMonth)
         let predicate = ItemPredicate.tagIs(tag)
         let items = try container.mainContext.fetch(.items(predicate))
 
@@ -129,7 +129,7 @@ struct ItemPredicateTest {
         let date = shiftedDate("2024-01-01T00:00:00Z")
         _ = try CreateItemIntent.perform((container: container, date: date, content: "Content", income: 0, outgo: 0, category: "Category", repeatCount: 1))
 
-        let tag = try Tag.create(context: container.mainContext, name: "Content", type: .content)
+        let tag = try Tag.create(container: container, name: "Content", type: .content)
         let predicate = ItemPredicate.tagAndYear(tag: tag, yearString: "2024")
         let items = try container.mainContext.fetch(.items(predicate))
 

--- a/IncomesTests/TimeZone/ItemTest.swift
+++ b/IncomesTests/TimeZone/ItemTest.swift
@@ -33,7 +33,7 @@ struct ItemTest {
         let repeatID = UUID()
 
         let item = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: date,
             content: content,
             income: income,
@@ -67,7 +67,7 @@ struct ItemTest {
         NSTimeZone.default = .init(identifier: "Asia/Tokyo")!
 
         let item = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: date,
             content: "Check",
             income: .zero,
@@ -83,7 +83,7 @@ struct ItemTest {
     func createAssignsDefaultValues() throws {
         let date = shiftedDate("2024-01-01T00:00:00Z")
         let item = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: date,
             content: "",
             income: .zero,
@@ -105,7 +105,7 @@ struct ItemTest {
 
         let date = shiftedDate("2024-06-10T12:00:00Z")
         let item = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: date,
             content: "Groceries",
             income: .zero,
@@ -126,7 +126,7 @@ struct ItemTest {
     @Test("modify updates values and regenerates tags with UTC-normalized date")
     func modifyUpdatesValuesAndRegeneratesTags() throws {
         let item = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: shiftedDate("2024-01-01T00:00:00Z"),
             content: "Old",
             income: 100,
@@ -169,7 +169,7 @@ struct ItemTest {
         NSTimeZone.default = .init(identifier: "Asia/Tokyo")!
 
         let item = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: shiftedDate("2024-01-01T00:00:00Z"),
             content: "Initial",
             income: 0,
@@ -196,7 +196,7 @@ struct ItemTest {
 
         let repeatID = UUID()
         let item = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: shiftedDate("2024-02-01T00:00:00Z"),
             content: "Init",
             income: 0,
@@ -223,7 +223,7 @@ struct ItemTest {
         NSTimeZone.default = timeZone
 
         let item = try Item.create(
-            context: container.mainContext,
+            container: container,
             date: shiftedDate("2024-07-01T10:00:00Z"),
             content: "Init",
             income: 0,


### PR DESCRIPTION
## Summary
- refactor create helpers and intents to use `container.mainContext` directly
- update debug preview store accordingly
- remove unnecessary local context variables

## Testing
- `swiftlint --fix --format --strict` *(fails: command not found)*
- `swift test` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6865df14da248320b8de582fbd20d0fd