### PR TITLE
Refine context menu preview

### DIFF
--- a/Incomes/Sources/Item/Components/ListItem.swift
+++ b/Incomes/Sources/Item/Components/ListItem.swift
@@ -55,7 +55,7 @@ struct ListItem: View {
                 isDeletePresented = true
             }
         } preview: {
-            ItemNavigationView()
+            ItemPreviewNavigationView()
                 .environment(item)
         }
         .sheet(isPresented: $isDetailPresented) {

--- a/Incomes/Sources/Item/Views/ItemPreviewNavigationView.swift
+++ b/Incomes/Sources/Item/Views/ItemPreviewNavigationView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ItemPreviewNavigationView {}
+
+extension ItemPreviewNavigationView: View {
+    var body: some View {
+        NavigationStack {
+            ItemPreviewView()
+        }
+    }
+}
+
+#Preview {
+    IncomesPreview { preview in
+        ItemPreviewNavigationView()
+            .environment(preview.items[0])
+    }
+}

--- a/Incomes/Sources/Item/Views/ItemPreviewView.swift
+++ b/Incomes/Sources/Item/Views/ItemPreviewView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import SwiftUtilities
+
+struct ItemPreviewView {
+    @Environment(ItemEntity.self)
+    private var item
+}
+
+extension ItemPreviewView: View {
+    var body: some View {
+        List {
+            ItemSection()
+        }
+        .navigationTitle(Text(item.content))
+    }
+}
+
+#Preview {
+    IncomesPreview { preview in
+        NavigationStack {
+            ItemPreviewView()
+                .environment(ItemEntity(preview.items[0])!)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- avoid showing unused buttons in context menu preview
- add `ItemPreviewView` for preview-only content
- add `ItemPreviewNavigationView` wrapping preview content
- remove debug section from preview

## Testing
- `pre-commit` *(fails: error 403 fetching SwiftLint)*
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6865e221c43483208e4b198a30b88cd0