### PR TITLE
Update to BridgeQuery

### DIFF
--- a/Incomes/Sources/Common/Models/IncomesPath.swift
+++ b/Incomes/Sources/Common/Models/IncomesPath.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 enum IncomesPath: Hashable {
-    case year(Tag)
-    case itemList(Tag)
-    case tag(Tag)
+    case year(TagEntity)
+    case itemList(TagEntity)
+    case tag(TagEntity)
 }

--- a/Incomes/Sources/Debug/Views/DebugListView.swift
+++ b/Incomes/Sources/Debug/Views/DebugListView.swift
@@ -34,9 +34,9 @@ extension DebugListView: View {
                     Text("Debug option")
                 }
             }
-            if let tag = try? GetAllTagsIntent.perform(context.container).first?.model(in: context) {
+            if let tagEntity = try? GetAllTagsIntent.perform(context.container).first.flatMap(TagEntity.init) {
                 Section {
-                    NavigationLink(value: IncomesPath.itemList(tag)) {
+                    NavigationLink(value: IncomesPath.itemList(tagEntity)) {
                         Text("All Items")
                     }
                     NavigationLink {

--- a/Incomes/Sources/Debug/Views/DebugListView.swift
+++ b/Incomes/Sources/Debug/Views/DebugListView.swift
@@ -34,7 +34,7 @@ extension DebugListView: View {
                     Text("Debug option")
                 }
             }
-            if let tagEntity = try? GetAllTagsIntent.perform(context.container).first.flatMap(TagEntity.init) {
+            if let tagEntity = try? GetAllTagsIntent.perform(context.container).first {
                 Section {
                     NavigationLink(value: IncomesPath.itemList(tagEntity)) {
                         Text("All Items")

--- a/Incomes/Sources/Debug/Views/DebugNavigationView.swift
+++ b/Incomes/Sources/Debug/Views/DebugNavigationView.swift
@@ -14,12 +14,12 @@ struct DebugNavigationView: View {
         NavigationSplitView {
             DebugListView(selection: $path)
         } detail: {
-            if case .itemList(let tag) = path {
+            if case .itemList(let tagEntity) = path {
                 ItemListView()
-                    .environment(tag)
-            } else if case .tag(let tag) = path {
+                    .environment(tagEntity)
+            } else if case .tag(let tagEntity) = path {
                 DebugTagView()
-                    .environment(tag)
+                    .environment(tagEntity)
             }
         }
     }

--- a/Incomes/Sources/Debug/Views/DebugTagListView.swift
+++ b/Incomes/Sources/Debug/Views/DebugTagListView.swift
@@ -1,35 +1,36 @@
 import SwiftData
 import SwiftUI
+import SwiftUtilities
 
 struct DebugTagListView: View {
-    @Query(.tags(.typeIs(.year))) private var years: [Tag]
-    @Query(.tags(.typeIs(.yearMonth))) private var yearMonths: [Tag]
-    @Query(.tags(.typeIs(.content))) private var contents: [Tag]
-    @Query(.tags(.typeIs(.category))) private var categories: [Tag]
+    @BridgeQuery(.tags(.typeIs(.year))) private var yearEntities: [TagEntity]
+    @BridgeQuery(.tags(.typeIs(.yearMonth))) private var yearMonthEntities: [TagEntity]
+    @BridgeQuery(.tags(.typeIs(.content))) private var contentEntities: [TagEntity]
+    @BridgeQuery(.tags(.typeIs(.category))) private var categoryEntities: [TagEntity]
 
     var body: some View {
         List {
-            buildSection(from: years) {
+            buildSection(from: yearEntities) {
                 Text("Year")
             }
-            buildSection(from: yearMonths) {
+            buildSection(from: yearMonthEntities) {
                 Text("YearMonth")
             }
-            buildSection(from: contents) {
+            buildSection(from: contentEntities) {
                 Text("Content")
             }
-            buildSection(from: categories) {
+            buildSection(from: categoryEntities) {
                 Text("Category")
             }
         }
     }
 
     @ViewBuilder
-    private func buildSection<Header: View>(from tags: [Tag], header: () -> Header) -> some View {
+    private func buildSection<Header: View>(from entities: [TagEntity], header: () -> Header) -> some View {
         Section {
-            ForEach(tags) { tag in
-                NavigationLink(value: IncomesPath.tag(tag)) {
-                    Text(tag.displayName)
+            ForEach(entities) { entity in
+                NavigationLink(value: IncomesPath.tag(entity)) {
+                    Text(entity.displayName)
                 }
             }
         } header: {

--- a/Incomes/Sources/Debug/Views/DebugTagListView.swift
+++ b/Incomes/Sources/Debug/Views/DebugTagListView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 import SwiftUtilities
 
 struct DebugTagListView: View {
-    @BridgeQuery(.tags(.typeIs(.year))) private var yearEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.yearMonth))) private var yearMonthEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.content))) private var contentEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.category))) private var categoryEntities: [TagEntity]
+    @BridgeQuery(.init(.tags(.typeIs(.year)))) private var yearEntities: [TagEntity]
+    @BridgeQuery(.init(.tags(.typeIs(.yearMonth)))) private var yearMonthEntities: [TagEntity]
+    @BridgeQuery(.init(.tags(.typeIs(.content)))) private var contentEntities: [TagEntity]
+    @BridgeQuery(.init(.tags(.typeIs(.category)))) private var categoryEntities: [TagEntity]
 
     var body: some View {
         List {

--- a/Incomes/Sources/Home/Components/HomeTabSection.swift
+++ b/Incomes/Sources/Home/Components/HomeTabSection.swift
@@ -14,7 +14,7 @@ struct HomeTabSection: View {
     @Environment(\.modelContext)
     private var context
 
-    @BridgeQuery(.tags(.typeIs(.year)))
+    @BridgeQuery(.init(.tags(.typeIs(.year))))
     private var yearTagEntities: [TagEntity]
 
     @Binding private var yearTagEntity: TagEntity?
@@ -62,7 +62,7 @@ struct HomeTabSection: View {
                 ForEach(availableYearTagEntities) { entity in
                     Circle()
                         .frame(width: 8)
-                        .foregroundStyle(self.yearTagEntity == entity ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
+                        .foregroundStyle(yearTagEntity == entity ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
                 }
             }
             .frame(maxWidth: .infinity)

--- a/Incomes/Sources/Home/Views/HomeListView.swift
+++ b/Incomes/Sources/Home/Views/HomeListView.swift
@@ -82,16 +82,16 @@ extension HomeListView: View {
         .task {
             if !hasLoaded {
                 hasLoaded = true
-                    yearTagEntity = try? GetTagByNameIntent.perform(
-                        (
-                            container: context.container,
-                            name: Date.now.stringValueWithoutLocale(.yyyy),
-                            type: .year
-                        )
-                    ).flatMap(TagEntity.init)
-                    isIntroductionPresented = (
-                        try? GetAllItemsCountIntent.perform(context.container).isZero
-                    ) ?? false
+                yearTagEntity = try? GetTagByNameIntent.perform(
+                    (
+                        container: context.container,
+                        name: Date.now.stringValueWithoutLocale(.yyyy),
+                        type: .year
+                    )
+                )
+                isIntroductionPresented = (
+                    try? GetAllItemsCountIntent.perform(context.container).isZero
+                ) ?? false
             }
 
             notificationService.refresh()

--- a/Incomes/Sources/Home/Views/HomeListView.swift
+++ b/Incomes/Sources/Home/Views/HomeListView.swift
@@ -22,7 +22,7 @@ struct HomeListView {
 
     @Binding private var path: IncomesPath?
 
-    @State private var yearTag: Tag?
+    @State private var yearTagEntity: TagEntity?
     @State private var hasLoaded = false
     @State private var isIntroductionPresented = false
     @State private var isSettingsPresented = false
@@ -36,12 +36,12 @@ struct HomeListView {
 extension HomeListView: View {
     var body: some View {
         List(selection: $path) {
-            HomeTabSection(selection: $yearTag)
+            HomeTabSection(selection: $yearTagEntity)
             if !isSubscribeOn {
                 AdvertisementSection(.small)
             }
-            if let yearTag {
-                HomeYearSection(yearTag: yearTag)
+            if let yearTagEntity {
+                HomeYearSection(yearTag: yearTagEntity)
             }
         }
         .listStyle(.insetGrouped)
@@ -82,13 +82,13 @@ extension HomeListView: View {
         .task {
             if !hasLoaded {
                 hasLoaded = true
-                    yearTag = try? GetTagByNameIntent.perform(
+                    yearTagEntity = try? GetTagByNameIntent.perform(
                         (
                             container: context.container,
                             name: Date.now.stringValueWithoutLocale(.yyyy),
                             type: .year
                         )
-                    )?.model(in: context)
+                    ).flatMap(TagEntity.init)
                     isIntroductionPresented = (
                         try? GetAllItemsCountIntent.perform(context.container).isZero
                     ) ?? false
@@ -97,12 +97,12 @@ extension HomeListView: View {
             notificationService.refresh()
             await notificationService.register()
         }
-        .onChange(of: yearTag) {
-            guard let yearTag,
+        .onChange(of: yearTagEntity) {
+            guard let yearTagEntity,
                   path != .none else {
                 return
             }
-            path = .year(yearTag)
+            path = .year(yearTagEntity)
         }
     }
 }

--- a/Incomes/Sources/Home/Views/HomeNavigationView.swift
+++ b/Incomes/Sources/Home/Views/HomeNavigationView.swift
@@ -14,12 +14,12 @@ struct HomeNavigationView: View {
         NavigationSplitView {
             HomeListView(selection: $path)
         } detail: {
-            if case .itemList(let tag) = path {
+            if case .itemList(let tagEntity) = path {
                 ItemListView()
-                    .environment(tag)
-            } else if case .year(let yearTag) = path {
+                    .environment(tagEntity)
+            } else if case .year(let yearTagEntity) = path {
                 YearChartsView()
-                    .environment(yearTag)
+                    .environment(yearTagEntity)
             }
         }
     }

--- a/Incomes/Sources/Item/Components/Chart/BalanceChartSection.swift
+++ b/Incomes/Sources/Item/Components/Chart/BalanceChartSection.swift
@@ -11,12 +11,12 @@ import SwiftUI
 import SwiftUtilities
 
 struct BalanceChartSection: View {
-    @Query private var items: [Item]
+    @BridgeQuery private var items: [ItemEntity]
 
     @State private var isPresented = false
 
     init(_ descriptor: FetchDescriptor<Item>) {
-        _items = .init(descriptor)
+        _items = BridgeQuery(Query(descriptor))
     }
 
     var body: some View {
@@ -79,11 +79,14 @@ private extension BalanceChartSection {
         }
     }
 
-    func date(of item: Item) -> Date {
-        item.localDate
+    func date(of item: ItemEntity) -> Date {
+        Calendar.current.shiftedDate(
+            componentsFrom: item.date,
+            in: .utc
+        )
     }
 
-    func balance(of item: Item) -> Decimal {
+    func balance(of item: ItemEntity) -> Decimal {
         item.balance
     }
 }

--- a/Incomes/Sources/Item/Components/Chart/CategoryChartSection.swift
+++ b/Incomes/Sources/Item/Components/Chart/CategoryChartSection.swift
@@ -8,12 +8,13 @@
 import Charts
 import SwiftData
 import SwiftUI
+import SwiftUtilities
 
 struct CategoryChartSection: View {
-    @Query private var items: [Item]
+    @BridgeQuery private var items: [ItemEntity]
 
     init(_ descriptor: FetchDescriptor<Item>) {
-        _items = .init(descriptor)
+        _items = BridgeQuery(Query(descriptor))
     }
 
     var body: some View {
@@ -21,11 +22,8 @@ struct CategoryChartSection: View {
             Chart(
                 Dictionary(
                     grouping: items.filter(\.income.isNotZero)
-                ) {
-                    guard let category = $0.category else {
-                        return "Others"
-                    }
-                    return category.displayName
+                ) { item in
+                    item.category ?? "Others"
                 }.map { displayName, items in
                     (
                         title: displayName,
@@ -55,11 +53,8 @@ struct CategoryChartSection: View {
             Chart(
                 Dictionary(
                     grouping: items.filter(\.outgo.isNotZero)
-                ) {
-                    guard let category = $0.category else {
-                        return "Others"
-                    }
-                    return category.displayName
+                ) { item in
+                    item.category ?? "Others"
                 }.map { displayName, items in
                     (
                         title: displayName,

--- a/Incomes/Sources/Item/Components/Chart/IncomeAndOutgoChartSection.swift
+++ b/Incomes/Sources/Item/Components/Chart/IncomeAndOutgoChartSection.swift
@@ -11,12 +11,12 @@ import SwiftUI
 import SwiftUtilities
 
 struct IncomeAndOutgoChartSection: View {
-    @Query private var items: [Item]
+    @BridgeQuery private var items: [ItemEntity]
 
     @State private var isPresented = false
 
     init(_ descriptor: FetchDescriptor<Item>) {
-        _items = .init(descriptor)
+        _items = BridgeQuery(Query(descriptor))
     }
 
     var body: some View {
@@ -82,15 +82,18 @@ private extension IncomeAndOutgoChartSection {
         }
     }
 
-    func date(of item: Item) -> Date {
-        item.localDate
+    func date(of item: ItemEntity) -> Date {
+        Calendar.current.shiftedDate(
+            componentsFrom: item.date,
+            in: .utc
+        )
     }
 
-    func income(of item: Item) -> Decimal {
+    func income(of item: ItemEntity) -> Decimal {
         item.income
     }
 
-    func outgo(of item: Item) -> Decimal {
+    func outgo(of item: ItemEntity) -> Decimal {
         item.outgo * -1
     }
 }

--- a/Incomes/Sources/Item/Components/SuggestionButtonGroup.swift
+++ b/Incomes/Sources/Item/Components/SuggestionButtonGroup.swift
@@ -7,15 +7,16 @@
 
 import SwiftData
 import SwiftUI
+import SwiftUtilities
 
 struct SuggestionButtonGroup: View {
-    @Query private var suggestions: [Tag]
+    @BridgeQuery private var suggestions: [TagEntity]
 
     @Binding private var input: String
 
     init(input: Binding<String>, type: TagType) {
         _input = input
-        _suggestions = .init(.tags(.nameContains(input.wrappedValue, type: type)))
+        _suggestions = .init(Query(.tags(.nameContains(input.wrappedValue, type: type))))
     }
 
     var body: some View {

--- a/Incomes/Sources/Tag/Models/TagEntity.swift
+++ b/Incomes/Sources/Tag/Models/TagEntity.swift
@@ -59,6 +59,16 @@ extension TagEntity: ModelBridgeable {
     }
 }
 
+extension TagEntity: Hashable {
+    static func == (lhs: TagEntity, rhs: TagEntity) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
 extension TagEntity {
     var type: TagType? {
         TagType(rawValue: typeID)

--- a/Incomes/Sources/Tag/Views/DuplicateTagListView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagListView.swift
@@ -5,10 +5,10 @@ import SwiftUtilities
 struct DuplicateTagListView: View {
     @Environment(\.modelContext) private var context
 
-    @BridgeQuery(.tags(.typeIs(.year))) private var yearEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.yearMonth))) private var yearMonthEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.content))) private var contentEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.category))) private var categoryEntities: [TagEntity]
+    @BridgeQuery(.init(.tags(.typeIs(.year)))) private var yearEntities: [TagEntity]
+    @BridgeQuery(.init(.tags(.typeIs(.yearMonth)))) private var yearMonthEntities: [TagEntity]
+    @BridgeQuery(.init(.tags(.typeIs(.content)))) private var contentEntities: [TagEntity]
+    @BridgeQuery(.init(.tags(.typeIs(.category)))) private var categoryEntities: [TagEntity]
 
     @Binding private var selection: TagEntity?
 

--- a/Incomes/Sources/Tag/Views/DuplicateTagNavigationView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagNavigationView.swift
@@ -1,14 +1,18 @@
 import SwiftUI
 
 struct DuplicateTagNavigationView: View {
-    @State private var detail: Tag?
+    @Environment(\.modelContext)
+    private var context
+    @State private var detail: TagEntity?
 
     var body: some View {
         NavigationSplitView {
             DuplicateTagListView(selection: $detail)
         } detail: {
-            if let detail {
-                DuplicateTagView(detail)
+            if let detail,
+               let tag = try? detail.model(in: context)
+            {
+                DuplicateTagView(tag)
             }
         }
     }

--- a/Incomes/Sources/Tag/Views/TagNavigationView.swift
+++ b/Incomes/Sources/Tag/Views/TagNavigationView.swift
@@ -20,9 +20,9 @@ struct TagNavigationView: View {
         NavigationSplitView {
             TagListView(tagType: tagType, selection: $path)
         } detail: {
-            if case .itemList(let tag) = path {
+            if case .itemList(let tagEntity) = path {
                 ItemListView()
-                    .environment(tag)
+                    .environment(tagEntity)
             }
         }
     }


### PR DESCRIPTION
## Summary
- use `TagEntity` in navigation path
- simplify debug tag list
- refactor home tab section to filter available tag entities
- show totals in home tab using `TagEntity`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6865e65733cc8320bd2fa718b213df09