### PR TITLE
Update preview store to return entities

### DIFF
--- a/Incomes/Sources/Common/Components/IntentChartSectionGroup.swift
+++ b/Incomes/Sources/Common/Components/IntentChartSectionGroup.swift
@@ -33,7 +33,9 @@ extension IntentChartSectionGroup: View {
         IntentChartSectionGroup(
             .items(
                 .idsAre(
-                    preview.items.prefix(10).map(\.id)
+                    preview.items.prefix(10).compactMap { idEntity in
+                        try? PersistentIdentifier(base64Encoded: idEntity.id)
+                    }
                 )
             )
         )

--- a/Incomes/Sources/Common/Components/IntentItemListSection.swift
+++ b/Incomes/Sources/Common/Components/IntentItemListSection.swift
@@ -28,6 +28,6 @@ struct IntentItemListSection: View {
 
 #Preview {
     IncomesPreview { preview in
-        IntentItemListSection(preview.items.compactMap(ItemEntity.init))
+        IntentItemListSection(preview.items)
     }
 }

--- a/Incomes/Sources/Debug/Components/DebugSection.swift
+++ b/Incomes/Sources/Debug/Components/DebugSection.swift
@@ -86,7 +86,7 @@ extension DebugSection: View {
     IncomesPreview { preview in
         List {
             DebugSection()
-                .environment(ItemEntity(preview.items[0])!)
+                .environment(preview.items[0])
         }
     }
 }

--- a/Incomes/Sources/Home/Components/HomeTabSectionLink.swift
+++ b/Incomes/Sources/Home/Components/HomeTabSectionLink.swift
@@ -57,7 +57,6 @@ extension HomeTabSectionLink: View {
                 .environment(
                     preview.tags
                         .first { $0.type == .year }
-                        .flatMap(TagEntity.init)
                 )
         }
     }

--- a/Incomes/Sources/Home/Components/HomeYearSection.swift
+++ b/Incomes/Sources/Home/Components/HomeYearSection.swift
@@ -87,8 +87,7 @@ struct HomeYearSection: View {
         List {
             HomeYearSection(
                 yearTag: preview.tags
-                    .first { $0.name == Date.now.stringValueWithoutLocale(.yyyy) }
-                    .flatMap(TagEntity.init)!
+                    .first { $0.name == Date.now.stringValueWithoutLocale(.yyyy) }!
             )
         }
     }

--- a/Incomes/Sources/Item/Components/DeleteItemButton.swift
+++ b/Incomes/Sources/Item/Components/DeleteItemButton.swift
@@ -71,6 +71,6 @@ extension DeleteItemButton: View {
 #Preview {
     IncomesPreview { preview in
         DeleteItemButton()
-            .environment(ItemEntity(preview.items[.zero])!)
+            .environment(preview.items[.zero])
     }
 }

--- a/Incomes/Sources/Item/Components/DuplicateItemButton.swift
+++ b/Incomes/Sources/Item/Components/DuplicateItemButton.swift
@@ -44,6 +44,6 @@ extension DuplicateItemButton: View {
 #Preview {
     IncomesPreview { preview in
         DuplicateItemButton()
-            .environment(ItemEntity(preview.items[.zero])!)
+            .environment(preview.items[.zero])
     }
 }

--- a/Incomes/Sources/Item/Components/EditItemButton.swift
+++ b/Incomes/Sources/Item/Components/EditItemButton.swift
@@ -44,6 +44,6 @@ extension EditItemButton: View {
 #Preview {
     IncomesPreview { preview in
         EditItemButton()
-            .environment(ItemEntity(preview.items[.zero])!)
+            .environment(preview.items[.zero])
     }
 }

--- a/Incomes/Sources/Item/Components/ItemSection.swift
+++ b/Incomes/Sources/Item/Components/ItemSection.swift
@@ -48,7 +48,7 @@ struct ItemSection: View {
     IncomesPreview { preview in
         List {
             ItemSection()
-                .environment(ItemEntity(preview.items[0])!)
+                .environment(preview.items[0])
         }
     }
 }

--- a/Incomes/Sources/Item/Components/ListItem.swift
+++ b/Incomes/Sources/Item/Components/ListItem.swift
@@ -104,7 +104,7 @@ struct ListItem: View {
     IncomesPreview { preview in
         List {
             ListItem()
-                .environment(ItemEntity(preview.items[0])!)
+                .environment(preview.items[0])
         }
     }
 }

--- a/Incomes/Sources/Item/Components/NarrowListItem.swift
+++ b/Incomes/Sources/Item/Components/NarrowListItem.swift
@@ -40,6 +40,6 @@ struct NarrowListItem: View {
 #Preview {
     IncomesPreview { preview in
         NarrowListItem()
-            .environment(ItemEntity(preview.items[0])!)
+            .environment(preview.items[0])
     }
 }

--- a/Incomes/Sources/Item/Components/ShowItemButton.swift
+++ b/Incomes/Sources/Item/Components/ShowItemButton.swift
@@ -46,6 +46,6 @@ extension ShowItemButton: View {
 #Preview {
     IncomesPreview { preview in
         ShowItemButton()
-            .environment(ItemEntity(preview.items[.zero])!)
+            .environment(preview.items[.zero])
     }
 }

--- a/Incomes/Sources/Item/Components/TitleListItem.swift
+++ b/Incomes/Sources/Item/Components/TitleListItem.swift
@@ -31,7 +31,7 @@ struct TitleListItem: View {
     IncomesPreview { preview in
         List {
             TitleListItem()
-                .environment(ItemEntity(preview.items[0])!)
+                .environment(preview.items[0])
         }
     }
 }

--- a/Incomes/Sources/Item/Components/WideListItem.swift
+++ b/Incomes/Sources/Item/Components/WideListItem.swift
@@ -43,6 +43,6 @@ struct WideListItem: View {
 #Preview(traits: .landscapeRight) {
     IncomesPreview { preview in
         WideListItem()
-            .environment(ItemEntity(preview.items[0])!)
+            .environment(preview.items[0])
     }
 }

--- a/Incomes/Sources/Item/Views/ItemListGroup.swift
+++ b/Incomes/Sources/Item/Views/ItemListGroup.swift
@@ -32,6 +32,6 @@ extension ItemListGroup: View {
 #Preview {
     IncomesPreview { preview in
         ItemListGroup()
-            .environment(TagEntity(preview.tags[0])!)
+            .environment(preview.tags[0])
     }
 }

--- a/Incomes/Sources/Item/Views/ItemPreviewView.swift
+++ b/Incomes/Sources/Item/Views/ItemPreviewView.swift
@@ -19,7 +19,7 @@ extension ItemPreviewView: View {
     IncomesPreview { preview in
         NavigationStack {
             ItemPreviewView()
-                .environment(ItemEntity(preview.items[0])!)
+                .environment(preview.items[0])
         }
     }
 }

--- a/Incomes/Sources/Item/Views/ItemView.swift
+++ b/Incomes/Sources/Item/Views/ItemView.swift
@@ -39,7 +39,7 @@ extension ItemView: View {
     IncomesPreview { preview in
         NavigationStack {
             ItemView()
-                .environment(ItemEntity(preview.items[0])!)
+                .environment(preview.items[0])
         }
     }
 }

--- a/Incomes/Sources/Tag/Views/DuplicateTagView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagView.swift
@@ -129,7 +129,7 @@ struct DuplicateTagView: View {
 }
 
 #Preview {
-    IncomesPreview { preview in
-        DuplicateTagView(preview.tags[0])
+    IncomesPreview { _ in
+        DuplicateTagNavigationView()
     }
 }


### PR DESCRIPTION
## Summary
- switch `IncomesPreviewStore` to store `ItemEntity` and `TagEntity`
- update preview code to use entity values directly
- adjust ID handling in `IntentChartSectionGroup`
- refresh previews accordingly

## Testing
- `apt-get update`
- `apt-get install -y swiftlint` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_686b638e4f548320bfb02ce145f1f038