### PR TITLE
Implement Tag editing UI

### DIFF
--- a/Incomes/Sources/Tag/Components/EditTagButton.swift
+++ b/Incomes/Sources/Tag/Components/EditTagButton.swift
@@ -1,0 +1,49 @@
+//
+//  EditTagButton.swift
+//  Incomes
+//
+//  Created by Codex on 2025/07/07.
+//
+
+import SwiftUI
+
+struct EditTagButton {
+    @Environment(TagEntity.self)
+    private var tag
+
+    @State private var isPresented = false
+
+    private let action: (() -> Void)?
+
+    init(action: (() -> Void)? = nil) {
+        self.action = action
+    }
+}
+
+extension EditTagButton: View {
+    var body: some View {
+        Button {
+            if let action {
+                action()
+            } else {
+                isPresented = true
+            }
+        } label: {
+            Label {
+                Text("Edit")
+            } icon: {
+                Image(systemName: "pencil")
+            }
+        }
+        .sheet(isPresented: $isPresented) {
+            TagFormNavigationView(mode: .edit)
+        }
+    }
+}
+
+#Preview {
+    IncomesPreview { preview in
+        EditTagButton()
+            .environment(preview.tags[0])
+    }
+}

--- a/Incomes/Sources/Tag/Intents/UpdateTagIntent.swift
+++ b/Incomes/Sources/Tag/Intents/UpdateTagIntent.swift
@@ -1,0 +1,33 @@
+import AppIntents
+import SwiftData
+import SwiftUtilities
+
+struct UpdateTagIntent: AppIntent, IntentPerformer {
+    typealias Input = (context: ModelContext, tag: TagEntity, name: String)
+    typealias Output = Void
+
+    @Parameter(title: "Tag")
+    private var tag: TagEntity
+    @Parameter(title: "Name")
+    private var name: String
+
+    @Dependency private var modelContainer: ModelContainer
+
+    nonisolated static let title: LocalizedStringResource = .init("Update Tag", table: "AppIntents")
+
+    static func perform(_ input: Input) throws -> Output {
+        let (context, entity, name) = input
+        let id = try PersistentIdentifier(base64Encoded: entity.id)
+        guard let model = try context.fetchFirst(
+            .tags(.idIs(id))
+        ) else {
+            throw TagError.tagNotFound
+        }
+        model.modify(name: name)
+    }
+
+    func perform() throws -> some IntentResult {
+        try Self.perform((context: modelContainer.mainContext, tag: tag, name: name))
+        return .result()
+    }
+}

--- a/Incomes/Sources/Tag/Models/Tag.swift
+++ b/Incomes/Sources/Tag/Models/Tag.swift
@@ -27,6 +27,10 @@ nonisolated final class Tag {
         tag.typeID = type.rawValue
         return tag
     }
+
+    func modify(name: String) {
+        self.name = name
+    }
 }
 
 extension Tag {

--- a/Incomes/Sources/Tag/Views/TagFormNavigationView.swift
+++ b/Incomes/Sources/Tag/Views/TagFormNavigationView.swift
@@ -1,0 +1,26 @@
+//
+//  TagFormNavigationView.swift
+//  Incomes
+//
+//  Created by Codex on 2025/07/07.
+//
+
+import SwiftUI
+
+struct TagFormNavigationView {
+    let mode: TagFormView.Mode
+}
+
+extension TagFormNavigationView: View {
+    var body: some View {
+        NavigationStack {
+            TagFormView(mode: mode)
+        }
+    }
+}
+
+#Preview {
+    IncomesPreview { _ in
+        TagFormNavigationView(mode: .edit)
+    }
+}

--- a/Incomes/Sources/Tag/Views/TagFormView.swift
+++ b/Incomes/Sources/Tag/Views/TagFormView.swift
@@ -1,0 +1,87 @@
+//
+//  TagFormView.swift
+//  Incomes
+//
+//  Created by Codex on 2025/07/07.
+//
+
+import SwiftData
+import SwiftUI
+import SwiftUtilities
+
+struct TagFormView: View {
+    enum Mode {
+        case edit
+    }
+
+    @Environment(TagEntity.self)
+    private var tag
+    @Environment(\.dismiss)
+    private var dismiss
+    @Environment(\.modelContext)
+    private var context
+
+    @State private var name = String.empty
+
+    let mode: Mode
+
+    init(mode: Mode) {
+        self.mode = mode
+    }
+
+    var body: some View {
+        Form {
+            HStack {
+                Text("Name")
+                Spacer()
+                TextField(String.empty, text: $name)
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+        .navigationTitle(Text("Edit"))
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(action: dismiss.callAsFunction) {
+                    Text("Cancel")
+                }
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: save) {
+                    Text("Save")
+                }
+                .bold()
+                .disabled(name.isEmpty)
+            }
+        }
+        .onAppear {
+            name = tag.name
+        }
+    }
+}
+
+private extension TagFormView {
+    func save() {
+        do {
+            try UpdateTagIntent.perform(
+                (
+                    context: context,
+                    tag: tag,
+                    name: name
+                )
+            )
+            Haptic.success.impact()
+        } catch {
+            assertionFailure(error.localizedDescription)
+        }
+        dismiss()
+    }
+}
+
+#Preview {
+    IncomesPreview { preview in
+        NavigationStack {
+            TagFormView(mode: .edit)
+                .environment(preview.tags[0])
+        }
+    }
+}

--- a/Incomes/Sources/Tag/Views/TagListView.swift
+++ b/Incomes/Sources/Tag/Views/TagListView.swift
@@ -47,6 +47,10 @@ struct TagListView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+                .contextMenu {
+                    EditTagButton()
+                        .environment(entity)
+                }
                 .hidden(
                     searchText.isNotEmpty
                         && (

--- a/IncomesTests/Default/Intent/UpdateTagIntentTest.swift
+++ b/IncomesTests/Default/Intent/UpdateTagIntentTest.swift
@@ -1,0 +1,42 @@
+@testable import Incomes
+import SwiftData
+import Testing
+
+@MainActor
+struct UpdateTagIntentTest {
+    let context: ModelContext
+
+    init() {
+        context = testContext
+    }
+
+    @Test func perform() throws {
+        let tag = try Tag.create(context: context, name: "name", type: .content)
+        try UpdateTagIntent.perform(
+            (
+                context: context,
+                tag: .init(tag)!,
+                name: "new"
+            )
+        )
+        let result = try #require(context.fetchFirst(.tags(.all)))
+        #expect(result.name == "new")
+    }
+
+    @Test func performNotFound() throws {
+        let entity = TagEntity(
+            id: UUID().uuidString,
+            name: "missing",
+            typeID: TagType.content.rawValue
+        )
+        #expect(throws: Error.self) {
+            try UpdateTagIntent.perform(
+                (
+                    context: context,
+                    tag: entity,
+                    name: "new"
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `modify(name:)` API to Tag model
- create an `UpdateTagIntent` intent
- build tag editing form and navigation
- add `EditTagButton` and context menu support in Tag list
- test tag updates

## Testing
- `pre-commit` *(fails: RPC failed; HTTP 403)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686bfd1a86688320bd6338d736aa06ad