### PR TITLE
Refactor Tag views to use model

### DIFF
--- a/Incomes/Sources/Tag/Models/Tag.swift
+++ b/Incomes/Sources/Tag/Models/Tag.swift
@@ -52,6 +52,16 @@ extension Tag {
 
 extension Tag: Identifiable {}
 
+extension Tag: Hashable {
+    static func == (lhs: Tag, rhs: Tag) -> Bool {
+        lhs.persistentModelID == rhs.persistentModelID
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(persistentModelID)
+    }
+}
+
 // MARK: - Test
 
 extension Tag {

--- a/Incomes/Sources/Tag/Views/DuplicateTagListView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagListView.swift
@@ -4,36 +4,36 @@ import SwiftUI
 struct DuplicateTagListView: View {
     @Environment(\.modelContext) private var context
 
-    @BridgeQuery(.tags(.typeIs(.year)))
-    private var yearEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.yearMonth)))
-    private var yearMonthEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.content)))
-    private var contentEntities: [TagEntity]
-    @BridgeQuery(.tags(.typeIs(.category)))
-    private var categoryEntities: [TagEntity]
+    @Query(.tags(.typeIs(.year)))
+    private var yearTags: [Tag]
+    @Query(.tags(.typeIs(.yearMonth)))
+    private var yearMonthTags: [Tag]
+    @Query(.tags(.typeIs(.content)))
+    private var contentTags: [Tag]
+    @Query(.tags(.typeIs(.category)))
+    private var categoryTags: [Tag]
 
-    @Binding private var selection: TagEntity?
+    @Binding private var selection: Tag?
 
     @State private var isResolveDialogPresented = false
     @State private var selectedTags = [Tag]()
 
-    init(selection: Binding<TagEntity?>) {
+    init(selection: Binding<Tag?>) {
         _selection = selection
     }
 
     var body: some View {
         List(selection: $selection) {
-            buildSection(from: yearEntities) {
+            buildSection(from: yearTags) {
                 Text("Year")
             }
-            buildSection(from: yearMonthEntities) {
+            buildSection(from: yearMonthTags) {
                 Text("YearMonth")
             }
-            buildSection(from: contentEntities) {
+            buildSection(from: contentTags) {
                 Text("Content")
             }
-            buildSection(from: categoryEntities) {
+            buildSection(from: categoryTags) {
                 Text("Category")
             }
         }
@@ -70,8 +70,7 @@ struct DuplicateTagListView: View {
         }
     }
 
-    private func buildSection<Header: View>(from entities: [TagEntity], header: () -> Header) -> some View {
-        let tags = entities.compactMap { try? $0.model(in: context) }
+    private func buildSection<Header: View>(from tags: [Tag], header: () -> Header) -> some View {
         let duplicates: [Tag]
         do {
             let entities = try FindDuplicateTagsIntent.perform(
@@ -95,11 +94,11 @@ struct DuplicateTagListView: View {
         if duplicates.isEmpty {
             return AnyView(EmptyView())
         }
-        let duplicateEntities = duplicates.compactMap(TagEntity.init)
+
         return AnyView(
             Section {
-                ForEach(duplicateEntities) { entity in
-                    Text((try? entity.model(in: context))?.displayName ?? "")
+                ForEach(duplicates) { tag in
+                    Text(tag.displayName)
                 }
             } header: {
                 HStack {

--- a/Incomes/Sources/Tag/Views/DuplicateTagNavigationView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagNavigationView.swift
@@ -1,17 +1,14 @@
 import SwiftUI
 
 struct DuplicateTagNavigationView: View {
-    @Environment(\.modelContext)
-    private var context
-    @State private var detail: TagEntity?
+    @State private var detail: Tag?
 
     var body: some View {
         NavigationSplitView {
             DuplicateTagListView(selection: $detail)
         } detail: {
-            if let detail,
-               let tag = try? detail.model(in: context) {
-                DuplicateTagView(tag)
+            if let detail {
+                DuplicateTagView(detail)
             }
         }
     }

--- a/Incomes/Sources/Tag/Views/DuplicateTagView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagView.swift
@@ -5,20 +5,20 @@ struct DuplicateTagView: View {
     @Environment(\.modelContext)
     private var context
 
-    @BridgeQuery private var tags: [TagEntity]
+    @Query private var tags: [Tag]
 
     @State private var isMergeDialogPresented = false
     @State private var isDeleteDialogPresented = false
     @State private var selectedTag: Tag?
 
     init(_ tag: Tag) {
-        _tags = .init(.tags(.isSameWith(tag)))
+        _tags = Query(.tags(.isSameWith(tag)))
     }
 
     var body: some View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: .zero) {
-                let tagModels = tags.compactMap { try? $0.model(in: context) }
+                let tagModels = tags
                 ForEach(tagModels) { tag in
                     List {
                         Section {
@@ -61,7 +61,7 @@ struct DuplicateTagView: View {
                     try MergeDuplicateTagsIntent.perform(
                         (
                             context: context,
-                            tags: tags
+                            tags: tags.compactMap(TagEntity.init)
                         )
                     )
                 } catch {

--- a/Incomes/Sources/Tag/Views/TagNavigationView.swift
+++ b/Incomes/Sources/Tag/Views/TagNavigationView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TagNavigationView: View {
-    @State private var tag: TagEntity?
+    @State private var tag: Tag?
 
     private let tagType: TagType
 
@@ -20,9 +20,9 @@ struct TagNavigationView: View {
         NavigationSplitView {
             TagListView(tagType: tagType, selection: $tag)
         } detail: {
-            if let tag {
+            if let tag, let entity = TagEntity.init(tag) {
                 ItemListGroup()
-                    .environment(tag)
+                    .environment(entity)
             }
         }
     }


### PR DESCRIPTION
## Summary
- refactor Tag navigation and lists to use `Tag` SwiftData model instead of `TagEntity`
- add `Hashable` conformance to `Tag`
- update duplicate tag views to work with `Tag`

## Testing
- `pre-commit run --files Incomes/Sources/Tag/Models/Tag.swift Incomes/Sources/Tag/Views/TagNavigationView.swift Incomes/Sources/Tag/Views/TagListView.swift Incomes/Sources/Tag/Views/DuplicateTagNavigationView.swift Incomes/Sources/Tag/Views/DuplicateTagListView.swift Incomes/Sources/Tag/Views/DuplicateTagView.swift` *(fails: RPC failed; HTTP 403)*
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_6871d3d13f6c832085de3f240ec018a5