### PR TITLE
refactor: delegate app intents to service layer

### DIFF
--- a/Incomes/Sources/Item/Intents/Create/InferItemFormIntent.swift
+++ b/Incomes/Sources/Item/Intents/Create/InferItemFormIntent.swift
@@ -13,40 +13,7 @@ struct InferItemFormIntent: AppIntent, IntentPerformer {
     typealias Output = ItemFormInference
 
     static func perform(_ input: Input) async throws -> Output {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd"
-        let today = formatter.string(from: Date())
-
-        let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
-        let session = LanguageModelSession(
-            instructions: """
-                You are a professional financial advisor for a household accounting and budgeting app. Carefully extract and output the necessary fields from user input as an expert accountant.
-                Always provide reliable and precise results.
-                """
-        )
-        let prompt = """
-            Today's date is: \(today)
-            You are a professional financial advisor for a household accounting and budgeting app. Carefully extract and output the following fields from the user input:
-            - date (yyyyMMdd) (If the date in the text is relative, such as 'last month' or 'next month', convert it to the correct date)
-            - content (description)
-            - income
-            - outgo
-            - category
-
-            REQUIREMENT:
-            - Respond ONLY with the values in the language: \(languageCode).
-            - Never reply in English unless the device language is English.
-            - All field values must be in the device's language, matching the user's input language.
-            - If the language is Japanese, return all labels and values in Japanese, and treat relative time expressions (like '来月', '先月') accurately.
-            - Output only the result values, no explanation, format, or extra words.
-
-            Text: \(input)
-            """
-        let response = try await session.respond(
-            to: prompt,
-            generating: ItemFormInference.self
-        )
-        return response.content
+        return try await ItemService.inferForm(text: input)
     }
 
     func perform() async throws -> some ReturnsValue<ItemFormInference> {

--- a/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
@@ -11,12 +11,7 @@ struct DeleteAllItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Delete All Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let items = try input.fetch(FetchDescriptor<Item>())
-        items.forEach { item in
-            item.delete()
-        }
-        let calculator = BalanceCalculator()
-        try calculator.calculate(in: input, for: items)
+        try ItemService.deleteAll(context: input)
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
@@ -14,18 +14,10 @@ struct DeleteItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Delete Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity) = input
-        guard
-            let id = try? PersistentIdentifier(base64Encoded: entity.id),
-            let model = try context.fetchFirst(
-                .items(.idIs(id))
-            )
-        else {
-            throw ItemError.itemNotFound
-        }
-        model.delete()
-        let calculator = BalanceCalculator()
-        try calculator.calculate(in: context, for: [model])
+        try ItemService.delete(
+            context: input.context,
+            item: input.item
+        )
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Item/Intents/Get/GetAllItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetAllItemsCountIntent.swift
@@ -11,7 +11,7 @@ struct GetAllItemsCountIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get All Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.fetchCount(.items(.all))
+        return try ItemService.allItemsCount(context: input)
     }
 
     func perform() throws -> some ReturnsValue<Int> {

--- a/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
@@ -22,10 +22,10 @@ struct GetItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let items = try input.context.fetch(
-            .items(.dateIsSameMonthAs(input.date))
+        return try ItemService.items(
+            context: input.context,
+            date: input.date
         )
-        return items.compactMap(ItemEntity.init)
     }
 
     func perform() throws -> some ReturnsValue<[ItemEntity]> {

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemContentIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemContentIntent.swift
@@ -22,16 +22,17 @@ struct GetNextItemContentIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Next Item Content", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {
-            return nil
-        }
-        return item.content
+        return try ItemService.nextItemContent(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<String?> {
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
-            return .result(value: nil)
-        }
-        return .result(value: item.content)
+        return .result(
+            value: try Self.perform(
+                (context: modelContainer.mainContext, date: date)
+            )
+        )
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemDateIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemDateIntent.swift
@@ -22,16 +22,17 @@ struct GetNextItemDateIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Next Item Date", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {
-            return nil
-        }
-        return item.date
+        return try ItemService.nextItemDate(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<Date?> {
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
-            return .result(value: nil)
-        }
-        return .result(value: item.date)
+        return .result(
+            value: try Self.perform(
+                (context: modelContainer.mainContext, date: date)
+            )
+        )
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemIntent.swift
@@ -22,11 +22,10 @@ struct GetNextItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Next Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let descriptor = FetchDescriptor.items(.dateIsAfter(input.date), order: .forward)
-        guard let item = try input.context.fetchFirst(descriptor) else {
-            return nil
-        }
-        return .init(item)
+        return try ItemService.nextItem(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<ItemEntity?> {

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemProfitIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemProfitIntent.swift
@@ -23,18 +23,17 @@ struct GetNextItemProfitIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Next Item Profit", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        guard let item = try GetNextItemIntent.perform((context: input.context, date: input.date)) else {
-            return nil
-        }
-        let currencyCode = AppStorage(.currencyCode).wrappedValue
-        return .init(amount: item.profit, currencyCode: currencyCode)
+        return try ItemService.nextItemProfit(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<IntentCurrencyAmount?> {
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
-            return .result(value: nil)
-        }
-        let currencyCode = AppStorage(.currencyCode).wrappedValue
-        return .result(value: .init(amount: item.profit, currencyCode: currencyCode))
+        return .result(
+            value: try Self.perform(
+                (context: modelContainer.mainContext, date: date)
+            )
+        )
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
@@ -22,14 +22,10 @@ struct GetNextItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Next Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let descriptor = FetchDescriptor.items(.dateIsAfter(input.date), order: .forward)
-        guard let item = try input.context.fetchFirst(descriptor) else {
-            return .empty
-        }
-        let items = try input.context.fetch(
-            .items(.dateIsSameDayAs(item.localDate))
+        return try ItemService.nextItems(
+            context: input.context,
+            date: input.date
         )
-        return items.compactMap(ItemEntity.init)
     }
 
     func perform() throws -> some ReturnsValue<[ItemEntity]> {

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemContentIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemContentIntent.swift
@@ -22,13 +22,17 @@ struct GetPreviousItemContentIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Item Content", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetPreviousItemIntent.perform(input)?.content
+        return try ItemService.previousItemContent(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<String?> {
-        guard let content = try Self.perform((context: modelContainer.mainContext, date: date)) else {
-            return .result(value: nil)
-        }
-        return .result(value: content)
+        return .result(
+            value: try Self.perform(
+                (context: modelContainer.mainContext, date: date)
+            )
+        )
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemDateIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemDateIntent.swift
@@ -22,16 +22,17 @@ struct GetPreviousItemDateIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Item Date", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        guard let item = try GetPreviousItemIntent.perform(input) else {
-            return nil
-        }
-        return item.date
+        return try ItemService.previousItemDate(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<Date?> {
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
-            return .result(value: nil)
-        }
-        return .result(value: item)
+        return .result(
+            value: try Self.perform(
+                (context: modelContainer.mainContext, date: date)
+            )
+        )
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemIntent.swift
@@ -22,11 +22,10 @@ struct GetPreviousItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let descriptor = FetchDescriptor.items(.dateIsBefore(input.date))
-        guard let item = try input.context.fetchFirst(descriptor) else {
-            return nil
-        }
-        return .init(item)
+        return try ItemService.previousItem(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<ItemEntity?> {

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemProfitIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemProfitIntent.swift
@@ -23,17 +23,17 @@ struct GetPreviousItemProfitIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Item Profit", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        guard let item = try GetPreviousItemIntent.perform(input) else {
-            return nil
-        }
-        let currencyCode = AppStorage(.currencyCode).wrappedValue
-        return .init(amount: item.profit, currencyCode: currencyCode)
+        return try ItemService.previousItemProfit(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<IntentCurrencyAmount?> {
-        guard let amount = try Self.perform((context: modelContainer.mainContext, date: date)) else {
-            return .result(value: nil)
-        }
-        return .result(value: amount)
+        return .result(
+            value: try Self.perform(
+                (context: modelContainer.mainContext, date: date)
+            )
+        )
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemsIntent.swift
@@ -22,14 +22,10 @@ struct GetPreviousItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let descriptor = FetchDescriptor.items(.dateIsBefore(input.date))
-        guard let item = try input.context.fetchFirst(descriptor) else {
-            return .empty
-        }
-        let items = try input.context.fetch(
-            .items(.dateIsSameDayAs(item.localDate))
+        return try ItemService.previousItems(
+            context: input.context,
+            date: input.date
         )
-        return items.compactMap(ItemEntity.init)
     }
 
     func perform() throws -> some ReturnsValue<[ItemEntity]> {

--- a/Incomes/Sources/Item/Intents/Get/GetRepeatItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetRepeatItemsCountIntent.swift
@@ -14,7 +14,10 @@ struct GetRepeatItemsCountIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Repeat Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.context.fetchCount(.items(.repeatIDIs(input.repeatID)))
+        return try ItemService.repeatItemsCount(
+            context: input.context,
+            repeatID: input.repeatID
+        )
     }
 
     func perform() throws -> some ReturnsValue<Int> {

--- a/Incomes/Sources/Item/Intents/Get/GetYearItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetYearItemsCountIntent.swift
@@ -14,7 +14,10 @@ struct GetYearItemsCountIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Year Items Count", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try input.context.fetchCount(.items(.dateIsSameYearAs(input.date)))
+        return try ItemService.yearItemsCount(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ReturnsValue<Int> {

--- a/Incomes/Sources/Item/Intents/Show/CreateAndShowItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/CreateAndShowItemIntent.swift
@@ -36,16 +36,14 @@ struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
         guard content.isNotEmpty else {
             throw ItemError.contentIsEmpty
         }
-        return try CreateItemIntent.perform(
-            (
-                context: context,
-                date: date,
-                content: content,
-                income: .init(income),
-                outgo: .init(outgo),
-                category: category,
-                repeatCount: repeatCount
-            )
+        return try ItemService.create(
+            context: context,
+            date: date,
+            content: content,
+            income: .init(income),
+            outgo: .init(outgo),
+            category: category,
+            repeatCount: repeatCount
         )
     }
 

--- a/Incomes/Sources/Item/Intents/Show/ShowChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowChartsIntent.swift
@@ -22,10 +22,10 @@ struct ShowChartsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Charts", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let items = try input.context.fetch(
-            .items(.dateIsSameMonthAs(input.date))
+        return try ItemService.items(
+            context: input.context,
+            date: input.date
         )
-        return items.compactMap(ItemEntity.init)
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
@@ -22,10 +22,10 @@ struct ShowItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let items = try input.context.fetch(
-            .items(.dateIsSameMonthAs(input.date))
+        return try ItemService.items(
+            context: input.context,
+            date: input.date
         )
-        return items.compactMap(ItemEntity.init)
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemIntent.swift
@@ -22,11 +22,16 @@ struct ShowNextItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Next Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetNextItemIntent.perform((context: input.context, date: input.date))
+        return try ItemService.nextItem(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        ) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
@@ -22,7 +22,10 @@ struct ShowNextItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Next Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetNextItemsIntent.perform(input)
+        return try ItemService.nextItems(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemIntent.swift
@@ -22,7 +22,10 @@ struct ShowPreviousItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Previous Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetPreviousItemIntent.perform(input)
+        return try ItemService.previousItem(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
@@ -22,7 +22,10 @@ struct ShowPreviousItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Previous Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetPreviousItemsIntent.perform(input)
+        return try ItemService.previousItems(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemIntent.swift
@@ -19,7 +19,10 @@ struct ShowRecentItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Recent Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetPreviousItemIntent.perform(input)
+        return try ItemService.previousItem(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
@@ -19,7 +19,10 @@ struct ShowRecentItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Recent Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetPreviousItemsIntent.perform(input)
+        return try ItemService.previousItems(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
@@ -19,7 +19,10 @@ struct ShowThisMonthChartsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show This Month's Charts", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try ShowChartsIntent.perform(input)
+        return try ItemService.items(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
@@ -19,7 +19,10 @@ struct ShowThisMonthItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show This Month's Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try ShowItemsIntent.perform(input)
+        return try ItemService.items(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemIntent.swift
@@ -19,12 +19,17 @@ struct ShowUpcomingItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Upcoming Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetNextItemIntent.perform((context: input.context, date: input.date))
+        return try ItemService.nextItem(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let item = try GetNextItemIntent.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try Self.perform(
+            (context: modelContainer.mainContext, date: date)
+        ) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
@@ -19,7 +19,10 @@ struct ShowUpcomingItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Show Upcoming Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        try GetNextItemsIntent.perform(input)
+        return try ItemService.nextItems(
+            context: input.context,
+            date: input.date
+        )
     }
 
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {

--- a/Incomes/Sources/Item/Intents/Update/RecalculateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/RecalculateItemIntent.swift
@@ -14,8 +14,7 @@ struct RecalculateItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Recalculate Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let calculator = BalanceCalculator()
-        try calculator.calculate(in: input.context, after: input.date)
+        try ItemService.recalculate(context: input.context, date: input.date)
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
@@ -25,26 +25,14 @@ struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Update All Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity, date, content, income, outgo, category) = input
-        guard
-            let id = try? PersistentIdentifier(base64Encoded: entity.id),
-            let model = try context.fetchFirst(
-                .items(.idIs(id))
-            )
-        else {
-            throw DebugError.default
-        }
-        try UpdateRepeatingItemsIntent.perform(
-            (
-                context: context,
-                item: entity,
-                date: date,
-                content: content,
-                income: income,
-                outgo: outgo,
-                category: category,
-                descriptor: .items(.repeatIDIs(model.repeatID))
-            )
+        try ItemService.updateAll(
+            context: input.context,
+            item: input.item,
+            date: input.date,
+            content: input.content,
+            income: input.income,
+            outgo: input.outgo,
+            category: input.category
         )
     }
 

--- a/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
@@ -25,31 +25,14 @@ struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Update Future Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity, date, content, income, outgo, category) = input
-        guard
-            let id = try? PersistentIdentifier(base64Encoded: entity.id),
-            let model = try context.fetchFirst(
-                .items(.idIs(id))
-            )
-        else {
-            throw DebugError.default
-        }
-        try UpdateRepeatingItemsIntent.perform(
-            (
-                context: context,
-                item: entity,
-                date: date,
-                content: content,
-                income: income,
-                outgo: outgo,
-                category: category,
-                descriptor: .items(
-                    .repeatIDAndDateIsAfter(
-                        repeatID: model.repeatID,
-                        date: model.localDate
-                    )
-                )
-            )
+        try ItemService.updateFuture(
+            context: input.context,
+            item: input.item,
+            date: input.date,
+            content: input.content,
+            income: input.income,
+            outgo: input.outgo,
+            category: input.category
         )
     }
 

--- a/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
@@ -25,25 +25,15 @@ struct UpdateItemIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Update Item", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity, date, content, income, outgo, category) = input
-        guard
-            let id = try? PersistentIdentifier(base64Encoded: entity.id),
-            let model = try context.fetchFirst(
-                .items(.idIs(id))
-            )
-        else {
-            throw DebugError.default
-        }
-        try model.modify(
-            date: date,
-            content: content,
-            income: income,
-            outgo: outgo,
-            category: category,
-            repeatID: .init()
+        try ItemService.update(
+            context: input.context,
+            item: input.item,
+            date: input.date,
+            content: input.content,
+            income: input.income,
+            outgo: input.outgo,
+            category: input.category
         )
-        let calculator = BalanceCalculator()
-        try calculator.calculate(in: context, for: [model])
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
@@ -34,30 +34,16 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Update Repeating Items", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity, date, content, income, outgo, category, descriptor) = input
-        let components = Calendar.current.dateComponents(
-            [.year, .month, .day],
-            from: entity.date,
-            to: date
+        try ItemService.updateRepeatingItems(
+            context: input.context,
+            item: input.item,
+            date: input.date,
+            content: input.content,
+            income: input.income,
+            outgo: input.outgo,
+            category: input.category,
+            descriptor: input.descriptor
         )
-        let repeatID = UUID()
-        let items = try context.fetch(descriptor)
-        try items.forEach { item in
-            guard let newDate = Calendar.current.date(byAdding: components, to: item.localDate) else {
-                assertionFailure()
-                return
-            }
-            try item.modify(
-                date: newDate,
-                content: content,
-                income: income,
-                outgo: outgo,
-                category: category,
-                repeatID: repeatID
-            )
-        }
-        let calculator = BalanceCalculator()
-        try calculator.calculate(in: context, for: items)
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Item/Services/ItemService.swift
+++ b/Incomes/Sources/Item/Services/ItemService.swift
@@ -188,11 +188,11 @@ enum ItemService {
     }
 
     static func nextItemDate(context: ModelContext, date: Date) throws -> Date? {
-        try nextItemModel(context: context, date: date)?.date
+        try nextItemModel(context: context, date: date)?.localDate
     }
 
     static func previousItemDate(context: ModelContext, date: Date) throws -> Date? {
-        try previousItemModel(context: context, date: date)?.date
+        try previousItemModel(context: context, date: date)?.localDate
     }
 
     static func nextItemContent(context: ModelContext, date: Date) throws -> String? {

--- a/Incomes/Sources/Item/Services/ItemService.swift
+++ b/Incomes/Sources/Item/Services/ItemService.swift
@@ -1,0 +1,350 @@
+import Foundation
+import SwiftData
+import SwiftUI
+
+@MainActor
+enum ItemService {
+    static func create(
+        context: ModelContext,
+        date: Date,
+        content: String,
+        income: Decimal,
+        outgo: Decimal,
+        category: String,
+        repeatCount: Int
+    ) throws -> ItemEntity {
+        var items = [Item]()
+        let repeatID = UUID()
+        let model = try Item.create(
+            context: context,
+            date: date,
+            content: content,
+            income: income,
+            outgo: outgo,
+            category: category,
+            repeatID: repeatID
+        )
+        items.append(model)
+        for index in 0..<repeatCount {
+            guard index > .zero else {
+                continue
+            }
+            guard let repeatingDate = Calendar.current.date(byAdding: .month, value: index, to: date) else {
+                assertionFailure()
+                continue
+            }
+            let item = try Item.create(
+                context: context,
+                date: repeatingDate,
+                content: content,
+                income: income,
+                outgo: outgo,
+                category: category,
+                repeatID: repeatID
+            )
+            items.append(item)
+        }
+        items.forEach(context.insert)
+        let calculator = BalanceCalculator()
+        try calculator.calculate(in: context, for: items)
+        guard let entity = ItemEntity(model) else {
+            throw ItemError.entityConversionFailed
+        }
+        return entity
+    }
+
+    static func inferForm(text: String) async throws -> ItemFormInference {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd"
+        let today = formatter.string(from: Date())
+        let languageCode = Locale.current.language.languageCode?.identifier ?? "en"
+        let session = LanguageModelSession(
+            instructions: """
+                You are a professional financial advisor for a household accounting and budgeting app. Carefully extract and output the necessary fields from user input as an expert accountant.
+                Always provide reliable and precise results.
+                """
+        )
+        let prompt = """
+            Today's date is: \(today)
+            You are a professional financial advisor for a household accounting and budgeting app. Carefully extract and output the following fields from the user input:
+            - date (yyyyMMdd) (If the date in the text is relative, such as 'last month' or 'next month', convert it to the correct date)
+            - content (description)
+            - income
+            - outgo
+            - category
+
+            REQUIREMENT:
+            - Respond ONLY with the values in the language: \(languageCode).
+            - Never reply in English unless the device language is English.
+            - All field values must be in the device's language, matching the user's input language.
+            - If the language is Japanese, return all labels and values in Japanese, and treat relative time expressions (like '来月', '先月') accurately.
+            - Output only the result values, no explanation, format, or extra words.
+
+            Text: \(text)
+            """
+        let response = try await session.respond(
+            to: prompt,
+            generating: ItemFormInference.self
+        )
+        return response.content
+    }
+
+    static func delete(context: ModelContext, item: ItemEntity) throws {
+        guard
+            let id = try? PersistentIdentifier(base64Encoded: item.id),
+            let model = try context.fetchFirst(
+                .items(.idIs(id))
+            )
+        else {
+            throw ItemError.itemNotFound
+        }
+        model.delete()
+        let calculator = BalanceCalculator()
+        try calculator.calculate(in: context, for: [model])
+    }
+
+    static func deleteAll(context: ModelContext) throws {
+        let items = try context.fetch(FetchDescriptor<Item>())
+        items.forEach { item in
+            item.delete()
+        }
+        let calculator = BalanceCalculator()
+        try calculator.calculate(in: context, for: items)
+    }
+
+    static func allItemsCount(context: ModelContext) throws -> Int {
+        try context.fetchCount(.items(.all))
+    }
+
+    static func repeatItemsCount(context: ModelContext, repeatID: UUID) throws -> Int {
+        try context.fetchCount(.items(.repeatIDIs(repeatID)))
+    }
+
+    static func yearItemsCount(context: ModelContext, date: Date) throws -> Int {
+        try context.fetchCount(.items(.dateIsSameYearAs(date)))
+    }
+
+    static func items(context: ModelContext, date: Date) throws -> [ItemEntity] {
+        let items = try context.fetch(
+            .items(.dateIsSameMonthAs(date))
+        )
+        return items.compactMap(ItemEntity.init)
+    }
+
+    private static func nextItemModel(
+        context: ModelContext,
+        date: Date
+    ) throws -> Item? {
+        let descriptor = FetchDescriptor.items(
+            .dateIsAfter(date),
+            order: .forward
+        )
+        return try context.fetchFirst(descriptor)
+    }
+
+    private static func previousItemModel(
+        context: ModelContext,
+        date: Date
+    ) throws -> Item? {
+        let descriptor = FetchDescriptor.items(.dateIsBefore(date))
+        return try context.fetchFirst(descriptor)
+    }
+
+    static func nextItem(context: ModelContext, date: Date) throws -> ItemEntity? {
+        guard let item = try nextItemModel(context: context, date: date) else {
+            return nil
+        }
+        return ItemEntity(item)
+    }
+
+    static func previousItem(context: ModelContext, date: Date) throws -> ItemEntity? {
+        guard let item = try previousItemModel(context: context, date: date) else {
+            return nil
+        }
+        return ItemEntity(item)
+    }
+
+    static func nextItems(context: ModelContext, date: Date) throws -> [ItemEntity] {
+        guard let item = try nextItemModel(context: context, date: date) else {
+            return []
+        }
+        let items = try context.fetch(
+            .items(.dateIsSameDayAs(item.localDate))
+        )
+        return items.compactMap(ItemEntity.init)
+    }
+
+    static func previousItems(context: ModelContext, date: Date) throws -> [ItemEntity] {
+        guard let item = try previousItemModel(context: context, date: date) else {
+            return []
+        }
+        let items = try context.fetch(
+            .items(.dateIsSameDayAs(item.localDate))
+        )
+        return items.compactMap(ItemEntity.init)
+    }
+
+    static func nextItemDate(context: ModelContext, date: Date) throws -> Date? {
+        try nextItemModel(context: context, date: date)?.date
+    }
+
+    static func previousItemDate(context: ModelContext, date: Date) throws -> Date? {
+        try previousItemModel(context: context, date: date)?.date
+    }
+
+    static func nextItemContent(context: ModelContext, date: Date) throws -> String? {
+        try nextItemModel(context: context, date: date)?.content
+    }
+
+    static func previousItemContent(context: ModelContext, date: Date) throws -> String? {
+        try previousItemModel(context: context, date: date)?.content
+    }
+
+    static func nextItemProfit(context: ModelContext, date: Date) throws -> IntentCurrencyAmount? {
+        guard let profit = try nextItemModel(context: context, date: date)?.profit else {
+            return nil
+        }
+        let currencyCode = AppStorage(.currencyCode).wrappedValue
+        return .init(amount: profit, currencyCode: currencyCode)
+    }
+
+    static func previousItemProfit(context: ModelContext, date: Date) throws -> IntentCurrencyAmount? {
+        guard let profit = try previousItemModel(context: context, date: date)?.profit else {
+            return nil
+        }
+        let currencyCode = AppStorage(.currencyCode).wrappedValue
+        return .init(amount: profit, currencyCode: currencyCode)
+    }
+
+    static func update(
+        context: ModelContext,
+        item: ItemEntity,
+        date: Date,
+        content: String,
+        income: Decimal,
+        outgo: Decimal,
+        category: String
+    ) throws {
+        guard
+            let id = try? PersistentIdentifier(base64Encoded: item.id),
+            let model = try context.fetchFirst(
+                .items(.idIs(id))
+            )
+        else {
+            throw DebugError.default
+        }
+        try model.modify(
+            date: date,
+            content: content,
+            income: income,
+            outgo: outgo,
+            category: category,
+            repeatID: .init()
+        )
+        let calculator = BalanceCalculator()
+        try calculator.calculate(in: context, for: [model])
+    }
+
+    static func updateRepeatingItems(
+        context: ModelContext,
+        item: ItemEntity,
+        date: Date,
+        content: String,
+        income: Decimal,
+        outgo: Decimal,
+        category: String,
+        descriptor: FetchDescriptor<Item>
+    ) throws {
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .day],
+            from: item.date,
+            to: date
+        )
+        let repeatID = UUID()
+        let items = try context.fetch(descriptor)
+        try items.forEach { item in
+            guard let newDate = Calendar.current.date(byAdding: components, to: item.localDate) else {
+                assertionFailure()
+                return
+            }
+            try item.modify(
+                date: newDate,
+                content: content,
+                income: income,
+                outgo: outgo,
+                category: category,
+                repeatID: repeatID
+            )
+        }
+        let calculator = BalanceCalculator()
+        try calculator.calculate(in: context, for: items)
+    }
+
+    static func updateAll(
+        context: ModelContext,
+        item: ItemEntity,
+        date: Date,
+        content: String,
+        income: Decimal,
+        outgo: Decimal,
+        category: String
+    ) throws {
+        guard
+            let id = try? PersistentIdentifier(base64Encoded: item.id),
+            let model = try context.fetchFirst(
+                .items(.idIs(id))
+            )
+        else {
+            throw DebugError.default
+        }
+        try updateRepeatingItems(
+            context: context,
+            item: item,
+            date: date,
+            content: content,
+            income: income,
+            outgo: outgo,
+            category: category,
+            descriptor: .items(.repeatIDIs(model.repeatID))
+        )
+    }
+
+    static func updateFuture(
+        context: ModelContext,
+        item: ItemEntity,
+        date: Date,
+        content: String,
+        income: Decimal,
+        outgo: Decimal,
+        category: String
+    ) throws {
+        guard
+            let id = try? PersistentIdentifier(base64Encoded: item.id),
+            let model = try context.fetchFirst(
+                .items(.idIs(id))
+            )
+        else {
+            throw DebugError.default
+        }
+        try updateRepeatingItems(
+            context: context,
+            item: item,
+            date: date,
+            content: content,
+            income: income,
+            outgo: outgo,
+            category: category,
+            descriptor: .items(
+                .repeatIDAndDateIsAfter(
+                    repeatID: model.repeatID,
+                    date: model.localDate
+                )
+            )
+        )
+    }
+
+    static func recalculate(context: ModelContext, date: Date) throws {
+        let calculator = BalanceCalculator()
+        try calculator.calculate(in: context, after: date)
+    }
+}

--- a/Incomes/Sources/Item/Services/ItemService.swift
+++ b/Incomes/Sources/Item/Services/ItemService.swift
@@ -1,4 +1,6 @@
+import AppIntents
 import Foundation
+import FoundationModels
 import SwiftData
 import SwiftUI
 
@@ -53,6 +55,7 @@ enum ItemService {
         return entity
     }
 
+    @available(iOS 26.0, *)
     static func inferForm(text: String) async throws -> ItemFormInference {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd"

--- a/Incomes/Sources/Main/Intents/OpenIncomesIntent.swift
+++ b/Incomes/Sources/Main/Intents/OpenIncomesIntent.swift
@@ -16,7 +16,9 @@ struct OpenIncomesIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Open Incomes", table: "AppIntents")
     nonisolated static let openAppWhenRun = true
 
-    static func perform(_: Input) throws -> Output {}
+    static func perform(_: Input) throws -> Output {
+        MainService.open()
+    }
 
     func perform() throws -> some IntentResult {
         try Self.perform(())

--- a/Incomes/Sources/Main/Services/MainService.swift
+++ b/Incomes/Sources/Main/Services/MainService.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@MainActor
+enum MainService {
+    static func open() {}
+}

--- a/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
@@ -11,10 +11,7 @@ struct DeleteAllTagsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Delete All Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let tags = try input.fetch(FetchDescriptor<Tag>())
-        tags.forEach { tag in
-            tag.delete()
-        }
+        try TagService.deleteAll(context: input)
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
@@ -14,14 +14,7 @@ struct DeleteTagIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Delete Tag", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entity) = input
-        let id = try PersistentIdentifier(base64Encoded: entity.id)
-        guard let model = try context.fetchFirst(
-            .tags(.idIs(id))
-        ) else {
-            throw TagError.tagNotFound
-        }
-        model.delete()
+        try TagService.delete(context: input.context, tag: input.tag)
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
@@ -14,23 +14,10 @@ struct FindDuplicateTagsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Find Duplicate Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entities) = input
-        let models: [Tag] = try entities.compactMap { entity in
-            let id = try PersistentIdentifier(base64Encoded: entity.id)
-            return try context.fetchFirst(
-                .tags(.idIs(id))
-            )
-        }
-        let duplicates = Dictionary(grouping: models) { tag in
-            tag.typeID + tag.name
-        }
-        .compactMap { _, values -> Tag? in
-            guard values.count > 1 else {
-                return nil
-            }
-            return values.first
-        }
-        return duplicates.compactMap(TagEntity.init)
+        return try TagService.findDuplicates(
+            context: input.context,
+            tags: input.tags
+        )
     }
 
     func perform() throws -> some ReturnsValue<[TagEntity]> {

--- a/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
@@ -11,8 +11,7 @@ struct GetAllTagsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get All Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let tags = try input.fetch(.tags(.all))
-        return tags.compactMap(TagEntity.init)
+        return try TagService.getAll(context: input)
     }
 
     func perform() throws -> some ReturnsValue<[TagEntity]> {

--- a/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
@@ -11,14 +11,7 @@ struct GetHasDuplicateTagsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Has Duplicate Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let tags = try GetAllTagsIntent.perform(input)
-        let duplicates = try FindDuplicateTagsIntent.perform(
-            (
-                context: input,
-                tags: tags
-            )
-        )
-        return !duplicates.isEmpty
+        return try TagService.hasDuplicates(context: input)
     }
 
     func perform() throws -> some ReturnsValue<Bool> {

--- a/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
@@ -14,13 +14,10 @@ struct GetTagByIDIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Tag By ID", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let persistentID = try PersistentIdentifier(base64Encoded: input.id)
-        guard let tag = try input.context.fetchFirst(
-            .tags(.idIs(persistentID))
-        ) else {
-            return nil
-        }
-        return TagEntity(tag)
+        return try TagService.getByID(
+            context: input.context,
+            id: input.id
+        )
     }
 
     func perform() throws -> some ReturnsValue<TagEntity?> {

--- a/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
@@ -16,10 +16,11 @@ struct GetTagByNameIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Get Tag By Name", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let tag = try input.context.fetchFirst(
-            .tags(.nameIs(input.name, type: input.type))
+        return try TagService.getByName(
+            context: input.context,
+            name: input.name,
+            type: input.type
         )
-        return tag.flatMap(TagEntity.init)
     }
 
     func perform() throws -> some ReturnsValue<TagEntity?> {

--- a/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
@@ -14,27 +14,10 @@ struct MergeDuplicateTagsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Merge Duplicate Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entities) = input
-        let models: [Tag] = try entities.compactMap { entity in
-            let id = try PersistentIdentifier(base64Encoded: entity.id)
-            return try context.fetchFirst(
-                .tags(.idIs(id))
-            )
-        }
-        guard let parent = models.first else {
-            return
-        }
-        let children = models.filter {
-            $0.id != parent.id
-        }
-        for item in children.flatMap({ $0.items ?? [] }) {
-            var tags = item.tags ?? []
-            tags.append(parent)
-            item.modify(tags: tags)
-        }
-        try children.compactMap(TagEntity.init).forEach { child in
-            try DeleteTagIntent.perform((context: context, tag: child))
-        }
+        try TagService.mergeDuplicates(
+            context: input.context,
+            tags: input.tags
+        )
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
@@ -14,24 +14,10 @@ struct ResolveDuplicateTagsIntent: AppIntent, IntentPerformer {
     nonisolated static let title: LocalizedStringResource = .init("Resolve Duplicate Tags", table: "AppIntents")
 
     static func perform(_ input: Input) throws -> Output {
-        let (context, entities) = input
-        let models: [Tag] = try entities.compactMap { entity in
-            let id = try PersistentIdentifier(base64Encoded: entity.id)
-            return try context.fetchFirst(
-                .tags(.idIs(id))
-            )
-        }
-        for model in models {
-            let duplicates = try context.fetch(
-                .tags(.isSameWith(model))
-            )
-            try MergeDuplicateTagsIntent.perform(
-                (
-                    context: context,
-                    tags: duplicates.compactMap(TagEntity.init)
-                )
-            )
-        }
+        try TagService.resolveDuplicates(
+            context: input.context,
+            tags: input.tags
+        )
     }
 
     func perform() throws -> some IntentResult {

--- a/Incomes/Sources/Tag/Services/TagService.swift
+++ b/Incomes/Sources/Tag/Services/TagService.swift
@@ -1,0 +1,123 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum TagService {
+    static func getAll(context: ModelContext) throws -> [TagEntity] {
+        let tags = try context.fetch(.tags(.all))
+        return tags.compactMap(TagEntity.init)
+    }
+
+    static func getByID(context: ModelContext, id: String) throws -> TagEntity? {
+        let persistentID = try PersistentIdentifier(base64Encoded: id)
+        guard let tag = try context.fetchFirst(
+            .tags(.idIs(persistentID))
+        ) else {
+            return nil
+        }
+        return TagEntity(tag)
+    }
+
+    static func getByName(
+        context: ModelContext,
+        name: String,
+        type: TagType
+    ) throws -> TagEntity? {
+        let tag = try context.fetchFirst(
+            .tags(.nameIs(name, type: type))
+        )
+        return tag.flatMap(TagEntity.init)
+    }
+
+    static func findDuplicates(
+        context: ModelContext,
+        tags: [TagEntity]
+    ) throws -> [TagEntity] {
+        let models: [Tag] = try tags.compactMap { entity in
+            let id = try PersistentIdentifier(base64Encoded: entity.id)
+            return try context.fetchFirst(
+                .tags(.idIs(id))
+            )
+        }
+        let duplicates = Dictionary(grouping: models) { tag in
+            tag.typeID + tag.name
+        }
+        .compactMap { _, values -> Tag? in
+            guard values.count > 1 else {
+                return nil
+            }
+            return values.first
+        }
+        return duplicates.compactMap(TagEntity.init)
+    }
+
+    static func hasDuplicates(context: ModelContext) throws -> Bool {
+        let tags = try getAll(context: context)
+        let duplicates = try findDuplicates(context: context, tags: tags)
+        return !duplicates.isEmpty
+    }
+
+    static func mergeDuplicates(
+        context: ModelContext,
+        tags: [TagEntity]
+    ) throws {
+        let models: [Tag] = try tags.compactMap { entity in
+            let id = try PersistentIdentifier(base64Encoded: entity.id)
+            return try context.fetchFirst(
+                .tags(.idIs(id))
+            )
+        }
+        guard let parent = models.first else {
+            return
+        }
+        let children = models.filter {
+            $0.id != parent.id
+        }
+        for item in children.flatMap({ $0.items ?? [] }) {
+            var tags = item.tags ?? []
+            tags.append(parent)
+            item.modify(tags: tags)
+        }
+        try children.compactMap(TagEntity.init).forEach { child in
+            try delete(context: context, tag: child)
+        }
+    }
+
+    static func resolveDuplicates(
+        context: ModelContext,
+        tags: [TagEntity]
+    ) throws {
+        let models: [Tag] = try tags.compactMap { entity in
+            let id = try PersistentIdentifier(base64Encoded: entity.id)
+            return try context.fetchFirst(
+                .tags(.idIs(id))
+            )
+        }
+        for model in models {
+            let duplicates = try context.fetch(
+                .tags(.isSameWith(model))
+            )
+            try mergeDuplicates(
+                context: context,
+                tags: duplicates.compactMap(TagEntity.init)
+            )
+        }
+    }
+
+    static func delete(context: ModelContext, tag: TagEntity) throws {
+        let id = try PersistentIdentifier(base64Encoded: tag.id)
+        guard let model = try context.fetchFirst(
+            .tags(.idIs(id))
+        ) else {
+            throw TagError.tagNotFound
+        }
+        model.delete()
+    }
+
+    static func deleteAll(context: ModelContext) throws {
+        let tags = try context.fetch(FetchDescriptor<Tag>())
+        tags.forEach { tag in
+            tag.delete()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ItemService, TagService, and MainService for core logic
- route all AppIntents through their services to thin adapter layer

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68980b042e648320b6d3d185a72342f5