### PR TITLE
Refactor intents to call services directly

### DIFF
--- a/Incomes/Sources/Home/Components/HomeYearSection.swift
+++ b/Incomes/Sources/Home/Components/HomeYearSection.swift
@@ -51,11 +51,9 @@ struct HomeYearSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.compactMap(ItemEntity.init).forEach {
-                        try DeleteItemIntent.perform(
-                            (
-                                context: context,
-                                item: $0
-                            )
+                        try ItemService.delete(
+                            context: context,
+                            item: $0
                         )
                     }
                     Haptic.success.impact()

--- a/Incomes/Sources/Home/Views/HomeListView.swift
+++ b/Incomes/Sources/Home/Views/HomeListView.swift
@@ -91,7 +91,7 @@ extension HomeListView: View {
                     )
                 )
                 isIntroductionPresented = (
-                    try? GetAllItemsCountIntent.perform(context).isZero
+                    try? ItemService.allItemsCount(context: context).isZero
                 ) ?? false
             }
 

--- a/Incomes/Sources/Item/Components/DeleteItemButton.swift
+++ b/Incomes/Sources/Item/Components/DeleteItemButton.swift
@@ -49,11 +49,9 @@ extension DeleteItemButton: View {
                         assertionFailure()
                         return
                     }
-                    try DeleteItemIntent.perform(
-                        (
-                            context: context,
-                            item: entity
-                        )
+                    try ItemService.delete(
+                        context: context,
+                        item: entity
                     )
                     Haptic.success.impact()
                 } catch {

--- a/Incomes/Sources/Item/Components/ItemFormOCRButton.swift
+++ b/Incomes/Sources/Item/Components/ItemFormOCRButton.swift
@@ -86,7 +86,7 @@ struct ItemFormOCRButton: View {
         do {
             try await scanner.scan(image)
             let text = scanner.recognizedText
-            let inference = try await InferItemFormIntent.perform(text)
+            let inference = try await ItemService.inferForm(text: text)
             if let newDate = inference.date.dateValueWithoutLocale(.yyyyMMdd) {
                 date = newDate
             }

--- a/Incomes/Sources/Item/Components/ItemListSection.swift
+++ b/Incomes/Sources/Item/Components/ItemListSection.swift
@@ -47,11 +47,9 @@ struct ItemListSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.compactMap(ItemEntity.init).forEach {
-                        try DeleteItemIntent.perform(
-                            (
-                                context: context,
-                                item: $0
-                            )
+                        try ItemService.delete(
+                            context: context,
+                            item: $0
                         )
                     }
                     Haptic.success.impact()

--- a/Incomes/Sources/Item/Components/ListItem.swift
+++ b/Incomes/Sources/Item/Components/ListItem.swift
@@ -81,11 +81,9 @@ struct ListItem: View {
                         assertionFailure()
                         return
                     }
-                    try DeleteItemIntent.perform(
-                        (
-                            context: context,
-                            item: entity
-                        )
+                    try ItemService.delete(
+                        context: context,
+                        item: entity
                     )
                     Haptic.success.impact()
                 } catch {

--- a/Incomes/Sources/Item/Components/TagItemListSection.swift
+++ b/Incomes/Sources/Item/Components/TagItemListSection.swift
@@ -46,11 +46,9 @@ extension TagItemListSection: View {
             Button(role: .destructive) {
                 do {
                     try willDeleteItems.compactMap(ItemEntity.init).forEach {
-                        try DeleteItemIntent.perform(
-                            (
-                                context: context,
-                                item: $0
-                            )
+                        try ItemService.delete(
+                            context: context,
+                            item: $0
                         )
                     }
                     Haptic.success.impact()

--- a/Incomes/Sources/Item/Intents/Create/CreateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Create/CreateItemIntent.swift
@@ -11,10 +11,7 @@ import SwiftData
 import SwiftUI
 
 @MainActor
-struct CreateItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date, content: String, income: Decimal, outgo: Decimal, category: String, repeatCount: Int)
-    typealias Output = ItemEntity
-
+struct CreateItemIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
     @Parameter(title: "Content")
@@ -32,18 +29,6 @@ struct CreateItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Create Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.create(
-            context: input.context,
-            date: input.date,
-            content: input.content,
-            income: input.income,
-            outgo: input.outgo,
-            category: input.category,
-            repeatCount: input.repeatCount
-        )
-    }
-
     func perform() throws -> some ReturnsValue<ItemEntity> {
         guard content.isNotEmpty else {
             throw $content.needsValueError()
@@ -57,16 +42,14 @@ struct CreateItemIntent: AppIntent, IntentPerformer {
             throw $outgo.needsDisambiguationError(among: [.init(amount: outgo.amount, currencyCode: currencyCode)])
         }
 
-        let item = try Self.perform(
-            (
-                context: modelContainer.mainContext,
-                date: date,
-                content: content,
-                income: income.amount,
-                outgo: outgo.amount,
-                category: category,
-                repeatCount: repeatCount
-            )
+        let item = try ItemService.create(
+            context: modelContainer.mainContext,
+            date: date,
+            content: content,
+            income: income.amount,
+            outgo: outgo.amount,
+            category: category,
+            repeatCount: repeatCount
         )
         return .result(value: item)
     }

--- a/Incomes/Sources/Item/Intents/Create/InferItemFormIntent.swift
+++ b/Incomes/Sources/Item/Intents/Create/InferItemFormIntent.swift
@@ -3,21 +3,14 @@ import FoundationModels
 
 @available(iOS 26.0, *)
 @MainActor
-struct InferItemFormIntent: AppIntent, IntentPerformer {
+struct InferItemFormIntent: AppIntent {
     nonisolated static let title: LocalizedStringResource = .init("Infer Item Form", table: "AppIntents")
 
     @Parameter(title: "Text")
     private var text: String
 
-    typealias Input = String
-    typealias Output = ItemFormInference
-
-    static func perform(_ input: Input) async throws -> Output {
-        return try await ItemService.inferForm(text: input)
-    }
-
     func perform() async throws -> some ReturnsValue<ItemFormInference> {
-        let result = try await Self.perform(text)
+        let result = try await ItemService.inferForm(text: text)
         return .result(value: result)
     }
 }

--- a/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteAllItemsIntent.swift
@@ -2,20 +2,13 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct DeleteAllItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
-    typealias Output = Void
-
+struct DeleteAllItemsIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Delete All Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try ItemService.deleteAll(context: input)
-    }
-
     func perform() throws -> some IntentResult {
-        try Self.perform(modelContainer.mainContext)
+        try ItemService.deleteAll(context: modelContainer.mainContext)
         return .result()
     }
 }

--- a/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Delete/DeleteItemIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct DeleteItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, item: ItemEntity)
-    typealias Output = Void
-
+struct DeleteItemIntent: AppIntent {
     @Parameter(title: "Item")
     private var item: ItemEntity
 
@@ -13,15 +10,11 @@ struct DeleteItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Delete Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try ItemService.delete(
-            context: input.context,
-            item: input.item
-        )
-    }
-
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, item: item))
+        try ItemService.delete(
+            context: modelContainer.mainContext,
+            item: item
+        )
         return .result()
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetAllItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetAllItemsCountIntent.swift
@@ -2,19 +2,12 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetAllItemsCountIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
-    typealias Output = Int
-
+struct GetAllItemsCountIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Get All Items Count", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.allItemsCount(context: input)
-    }
-
     func perform() throws -> some ReturnsValue<Int> {
-        .result(value: try Self.perform(modelContainer.mainContext))
+        .result(value: try ItemService.allItemsCount(context: modelContainer.mainContext))
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetItemsIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct GetItemsIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,15 +18,11 @@ struct GetItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.items(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
-        let items = try Self.perform((context: modelContainer.mainContext, date: date))
+        let items = try ItemService.items(
+            context: modelContainer.mainContext,
+            date: date
+        )
         return .result(value: items)
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemContentIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemContentIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetNextItemContentIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = String?
-
+struct GetNextItemContentIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,17 +18,11 @@ struct GetNextItemContentIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Next Item Content", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItemContent(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<String?> {
         return .result(
-            value: try Self.perform(
-                (context: modelContainer.mainContext, date: date)
+            value: try ItemService.nextItemContent(
+                context: modelContainer.mainContext,
+                date: date
             )
         )
     }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemDateIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemDateIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetNextItemDateIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = Date?
-
+struct GetNextItemDateIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,17 +18,11 @@ struct GetNextItemDateIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Next Item Date", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItemDate(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<Date?> {
         return .result(
-            value: try Self.perform(
-                (context: modelContainer.mainContext, date: date)
+            value: try ItemService.nextItemDate(
+                context: modelContainer.mainContext,
+                date: date
             )
         )
     }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetNextItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
-
+struct GetNextItemIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,15 +18,11 @@ struct GetNextItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Next Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItem(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<ItemEntity?> {
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try ItemService.nextItem(
+            context: modelContainer.mainContext,
+            date: date
+        ) else {
             return .result(value: nil)
         }
         return .result(value: item)

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemProfitIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemProfitIntent.swift
@@ -11,10 +11,7 @@ import SwiftData
 import SwiftUI
 
 @MainActor
-struct GetNextItemProfitIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = IntentCurrencyAmount?
-
+struct GetNextItemProfitIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -22,17 +19,11 @@ struct GetNextItemProfitIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Next Item Profit", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItemProfit(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<IntentCurrencyAmount?> {
         return .result(
-            value: try Self.perform(
-                (context: modelContainer.mainContext, date: date)
+            value: try ItemService.nextItemProfit(
+                context: modelContainer.mainContext,
+                date: date
             )
         )
     }

--- a/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetNextItemsIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetNextItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct GetNextItemsIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,16 +18,10 @@ struct GetNextItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Next Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItems(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
-        let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let items = try ItemService.nextItems(
+            context: modelContainer.mainContext,
+            date: date
         )
         return .result(value: items)
     }

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemContentIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemContentIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetPreviousItemContentIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = String?
-
+struct GetPreviousItemContentIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,17 +18,11 @@ struct GetPreviousItemContentIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Item Content", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItemContent(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<String?> {
         return .result(
-            value: try Self.perform(
-                (context: modelContainer.mainContext, date: date)
+            value: try ItemService.previousItemContent(
+                context: modelContainer.mainContext,
+                date: date
             )
         )
     }

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemDateIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemDateIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetPreviousItemDateIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = Date?
-
+struct GetPreviousItemDateIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,17 +18,11 @@ struct GetPreviousItemDateIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Item Date", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItemDate(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<Date?> {
         return .result(
-            value: try Self.perform(
-                (context: modelContainer.mainContext, date: date)
+            value: try ItemService.previousItemDate(
+                context: modelContainer.mainContext,
+                date: date
             )
         )
     }

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetPreviousItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
-
+struct GetPreviousItemIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,15 +18,11 @@ struct GetPreviousItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItem(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<ItemEntity?> {
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try ItemService.previousItem(
+            context: modelContainer.mainContext,
+            date: date
+        ) else {
             return .result(value: nil)
         }
         return .result(value: item)

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemProfitIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemProfitIntent.swift
@@ -11,10 +11,7 @@ import SwiftData
 import SwiftUI
 
 @MainActor
-struct GetPreviousItemProfitIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = IntentCurrencyAmount?
-
+struct GetPreviousItemProfitIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -22,17 +19,11 @@ struct GetPreviousItemProfitIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Item Profit", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItemProfit(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<IntentCurrencyAmount?> {
         return .result(
-            value: try Self.perform(
-                (context: modelContainer.mainContext, date: date)
+            value: try ItemService.previousItemProfit(
+                context: modelContainer.mainContext,
+                date: date
             )
         )
     }

--- a/Incomes/Sources/Item/Intents/Get/GetPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetPreviousItemsIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetPreviousItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct GetPreviousItemsIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,16 +18,10 @@ struct GetPreviousItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Previous Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItems(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<[ItemEntity]> {
-        let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let items = try ItemService.previousItems(
+            context: modelContainer.mainContext,
+            date: date
         )
         return .result(value: items)
     }

--- a/Incomes/Sources/Item/Intents/Get/GetRepeatItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetRepeatItemsCountIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetRepeatItemsCountIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, repeatID: UUID)
-    typealias Output = Int
-
+struct GetRepeatItemsCountIntent: AppIntent {
     @Parameter(title: "Repeat ID")
     private var repeatID: String
 
@@ -13,17 +10,13 @@ struct GetRepeatItemsCountIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Repeat Items Count", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.repeatItemsCount(
-            context: input.context,
-            repeatID: input.repeatID
-        )
-    }
-
     func perform() throws -> some ReturnsValue<Int> {
         guard let uuid = UUID(uuidString: repeatID) else {
             throw DebugError.default
         }
-        return .result(value: try Self.perform((context: modelContainer.mainContext, repeatID: uuid)))
+        return .result(value: try ItemService.repeatItemsCount(
+            context: modelContainer.mainContext,
+            repeatID: uuid
+        ))
     }
 }

--- a/Incomes/Sources/Item/Intents/Get/GetYearItemsCountIntent.swift
+++ b/Incomes/Sources/Item/Intents/Get/GetYearItemsCountIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetYearItemsCountIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = Int
-
+struct GetYearItemsCountIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -13,14 +10,10 @@ struct GetYearItemsCountIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Year Items Count", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.yearItemsCount(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ReturnsValue<Int> {
-        .result(value: try Self.perform((context: modelContainer.mainContext, date: date)))
+        .result(value: try ItemService.yearItemsCount(
+            context: modelContainer.mainContext,
+            date: date
+        ))
     }
 }

--- a/Incomes/Sources/Item/Intents/Show/CreateAndShowItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/CreateAndShowItemIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date, content: String, income: Double, outgo: Double, category: String, repeatCount: Int)
-    typealias Output = ItemEntity
-
+struct CreateAndShowItemIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
     @Parameter(title: "Content")
@@ -31,13 +28,12 @@ struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Create and Show Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        let (context, date, content, income, outgo, category, repeatCount) = input
+    func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         guard content.isNotEmpty else {
             throw ItemError.contentIsEmpty
         }
-        return try ItemService.create(
-            context: context,
+        let item = try ItemService.create(
+            context: modelContainer.mainContext,
             date: date,
             content: content,
             income: .init(income),
@@ -45,16 +41,6 @@ struct CreateAndShowItemIntent: AppIntent, IntentPerformer {
             category: category,
             repeatCount: repeatCount
         )
-    }
-
-    func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        let item = try Self.perform((context: modelContainer.mainContext,
-                                     date: date,
-                                     content: content,
-                                     income: income,
-                                     outgo: outgo,
-                                     category: category,
-                                     repeatCount: repeatCount))
         return .result(dialog: .init(stringLiteral: item.content)) {
             IntentItemSection()
                 .environment(try! item.model(in: modelContainer.mainContext))

--- a/Incomes/Sources/Item/Intents/Show/ShowChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowChartsIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowChartsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct ShowChartsIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,16 +18,10 @@ struct ShowChartsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Show Charts", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.items(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        let entities = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let entities = try ItemService.items(
+            context: modelContainer.mainContext,
+            date: date
         )
         guard entities.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowItemsIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct ShowItemsIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,16 +18,10 @@ struct ShowItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Show Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.items(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let items = try ItemService.items(
+            context: modelContainer.mainContext,
+            date: date
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowNextItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
-
+struct ShowNextItemIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,16 +18,10 @@ struct ShowNextItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Show Next Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItem(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let item = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        guard let item = try ItemService.nextItem(
+            context: modelContainer.mainContext,
+            date: date
         ) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }

--- a/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowNextItemsIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowNextItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct ShowNextItemsIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,16 +18,10 @@ struct ShowNextItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Show Next Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItems(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let items = try ItemService.nextItems(
+            context: modelContainer.mainContext,
+            date: date
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowPreviousItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
-
+struct ShowPreviousItemIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,15 +18,11 @@ struct ShowPreviousItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Show Previous Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItem(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try ItemService.previousItem(
+            context: modelContainer.mainContext,
+            date: date
+        ) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowPreviousItemsIntent.swift
@@ -10,10 +10,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowPreviousItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct ShowPreviousItemsIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -21,16 +18,10 @@ struct ShowPreviousItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Show Previous Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItems(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
-        let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let items = try ItemService.previousItems(
+            context: modelContainer.mainContext,
+            date: date
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemIntent.swift
@@ -10,24 +10,17 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowRecentItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
-
+struct ShowRecentItemIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Show Recent Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItem(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let item = try Self.perform((context: modelContainer.mainContext, date: date)) else {
+        guard let item = try ItemService.previousItem(
+            context: modelContainer.mainContext,
+            date: date
+        ) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }
         return .result(dialog: .init(stringLiteral: item.content)) {

--- a/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowRecentItemsIntent.swift
@@ -10,25 +10,16 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowRecentItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct ShowRecentItemsIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Show Recent Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.previousItems(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let items = try ItemService.previousItems(
+            context: modelContainer.mainContext,
+            date: date
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthChartsIntent.swift
@@ -10,25 +10,16 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowThisMonthChartsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct ShowThisMonthChartsIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Show This Month's Charts", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.items(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        let entities = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let entities = try ItemService.items(
+            context: modelContainer.mainContext,
+            date: date
         )
         guard entities.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowThisMonthItemsIntent.swift
@@ -10,25 +10,16 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowThisMonthItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct ShowThisMonthItemsIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Show This Month's Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.items(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let items = try ItemService.items(
+            context: modelContainer.mainContext,
+            date: date
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemIntent.swift
@@ -10,25 +10,16 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowUpcomingItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = ItemEntity?
-
+struct ShowUpcomingItemIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Show Upcoming Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItem(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        guard let item = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        guard let item = try ItemService.nextItem(
+            context: modelContainer.mainContext,
+            date: date
         ) else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))
         }

--- a/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Show/ShowUpcomingItemsIntent.swift
@@ -10,25 +10,16 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ShowUpcomingItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = [ItemEntity]
-
+struct ShowUpcomingItemsIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Show Upcoming Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try ItemService.nextItems(
-            context: input.context,
-            date: input.date
-        )
-    }
-
     func perform() throws -> some ProvidesDialog & ShowsSnippetView {
         let date = Date.now
-        let items = try Self.perform(
-            (context: modelContainer.mainContext, date: date)
+        let items = try ItemService.nextItems(
+            context: modelContainer.mainContext,
+            date: date
         )
         guard items.isNotEmpty else {
             return .result(dialog: .init(.init("Not Found", table: "AppIntents")))

--- a/Incomes/Sources/Item/Intents/Update/RecalculateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/RecalculateItemIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct RecalculateItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, date: Date)
-    typealias Output = Void
-
+struct RecalculateItemIntent: AppIntent {
     @Parameter(title: "Date", kind: .date)
     private var date: Date
 
@@ -13,12 +10,8 @@ struct RecalculateItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Recalculate Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try ItemService.recalculate(context: input.context, date: input.date)
-    }
-
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, date: date))
+        try ItemService.recalculate(context: modelContainer.mainContext, date: date)
         return .result()
     }
 }

--- a/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateAllItemsIntent.swift
@@ -3,10 +3,7 @@ import SwiftData
 import SwiftUI
 
 @MainActor
-struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
-    typealias Output = Void
-
+struct UpdateAllItemsIntent: AppIntent {
     @Parameter(title: "Item")
     private var item: ItemEntity
     @Parameter(title: "Date", kind: .date)
@@ -24,18 +21,6 @@ struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Update All Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try ItemService.updateAll(
-            context: input.context,
-            item: input.item,
-            date: input.date,
-            content: input.content,
-            income: input.income,
-            outgo: input.outgo,
-            category: input.category
-        )
-    }
-
     func perform() throws -> some IntentResult {
         let currencyCode = AppStorage(.currencyCode).wrappedValue
         guard income.currencyCode == currencyCode else {
@@ -44,16 +29,14 @@ struct UpdateAllItemsIntent: AppIntent, IntentPerformer {
         guard outgo.currencyCode == currencyCode else {
             throw $outgo.needsDisambiguationError(among: [.init(amount: outgo.amount, currencyCode: currencyCode)])
         }
-        try Self.perform(
-            (
-                context: modelContainer.mainContext,
-                item: item,
-                date: date,
-                content: content,
-                income: income.amount,
-                outgo: outgo.amount,
-                category: category
-            )
+        try ItemService.updateAll(
+            context: modelContainer.mainContext,
+            item: item,
+            date: date,
+            content: content,
+            income: income.amount,
+            outgo: outgo.amount,
+            category: category
         )
         return .result()
     }

--- a/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateFutureItemsIntent.swift
@@ -3,10 +3,7 @@ import SwiftData
 import SwiftUI
 
 @MainActor
-struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
-    typealias Output = Void
-
+struct UpdateFutureItemsIntent: AppIntent {
     @Parameter(title: "Item")
     private var item: ItemEntity
     @Parameter(title: "Date", kind: .date)
@@ -24,18 +21,6 @@ struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Update Future Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try ItemService.updateFuture(
-            context: input.context,
-            item: input.item,
-            date: input.date,
-            content: input.content,
-            income: input.income,
-            outgo: input.outgo,
-            category: input.category
-        )
-    }
-
     func perform() throws -> some IntentResult {
         let currencyCode = AppStorage(.currencyCode).wrappedValue
         guard income.currencyCode == currencyCode else {
@@ -44,16 +29,14 @@ struct UpdateFutureItemsIntent: AppIntent, IntentPerformer {
         guard outgo.currencyCode == currencyCode else {
             throw $outgo.needsDisambiguationError(among: [.init(amount: outgo.amount, currencyCode: currencyCode)])
         }
-        try Self.perform(
-            (
-                context: modelContainer.mainContext,
-                item: item,
-                date: date,
-                content: content,
-                income: income.amount,
-                outgo: outgo.amount,
-                category: category
-            )
+        try ItemService.updateFuture(
+            context: modelContainer.mainContext,
+            item: item,
+            date: date,
+            content: content,
+            income: income.amount,
+            outgo: outgo.amount,
+            category: category
         )
         return .result()
     }

--- a/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateItemIntent.swift
@@ -3,10 +3,7 @@ import SwiftData
 import SwiftUI
 
 @MainActor
-struct UpdateItemIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, item: ItemEntity, date: Date, content: String, income: Decimal, outgo: Decimal, category: String)
-    typealias Output = Void
-
+struct UpdateItemIntent: AppIntent {
     @Parameter(title: "Item")
     private var item: ItemEntity
     @Parameter(title: "Date", kind: .date)
@@ -24,18 +21,6 @@ struct UpdateItemIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Update Item", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try ItemService.update(
-            context: input.context,
-            item: input.item,
-            date: input.date,
-            content: input.content,
-            income: input.income,
-            outgo: input.outgo,
-            category: input.category
-        )
-    }
-
     func perform() throws -> some IntentResult {
         let currencyCode = AppStorage(.currencyCode).wrappedValue
         guard income.currencyCode == currencyCode else {
@@ -44,16 +29,14 @@ struct UpdateItemIntent: AppIntent, IntentPerformer {
         guard outgo.currencyCode == currencyCode else {
             throw $outgo.needsDisambiguationError(among: [.init(amount: outgo.amount, currencyCode: currencyCode)])
         }
-        try Self.perform(
-            (
-                context: modelContainer.mainContext,
-                item: item,
-                date: date,
-                content: content,
-                income: income.amount,
-                outgo: outgo.amount,
-                category: category
-            )
+        try ItemService.update(
+            context: modelContainer.mainContext,
+            item: item,
+            date: date,
+            content: content,
+            income: income.amount,
+            outgo: outgo.amount,
+            category: category
         )
         return .result()
     }

--- a/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
+++ b/Incomes/Sources/Item/Intents/Update/UpdateRepeatingItemsIntent.swift
@@ -3,19 +3,7 @@ import SwiftData
 import SwiftUI
 
 @MainActor
-struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
-    typealias Input = (
-        context: ModelContext,
-        item: ItemEntity,
-        date: Date,
-        content: String,
-        income: Decimal,
-        outgo: Decimal,
-        category: String,
-        descriptor: FetchDescriptor<Item>
-    )
-    typealias Output = Void
-
+struct UpdateRepeatingItemsIntent: AppIntent {
     @Parameter(title: "Item")
     private var item: ItemEntity
     @Parameter(title: "Date", kind: .date)
@@ -33,19 +21,6 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Update Repeating Items", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try ItemService.updateRepeatingItems(
-            context: input.context,
-            item: input.item,
-            date: input.date,
-            content: input.content,
-            income: input.income,
-            outgo: input.outgo,
-            category: input.category,
-            descriptor: input.descriptor
-        )
-    }
-
     func perform() throws -> some IntentResult {
         let currencyCode = AppStorage(.currencyCode).wrappedValue
         guard income.currencyCode == currencyCode else {
@@ -60,17 +35,15 @@ struct UpdateRepeatingItemsIntent: AppIntent, IntentPerformer {
         else {
             throw DebugError.default
         }
-        try Self.perform(
-            (
-                context: modelContainer.mainContext,
-                item: item,
-                date: date,
-                content: content,
-                income: income.amount,
-                outgo: outgo.amount,
-                category: category,
-                descriptor: .items(.repeatIDIs(model.repeatID))
-            )
+        try ItemService.updateRepeatingItems(
+            context: modelContainer.mainContext,
+            item: item,
+            date: date,
+            content: content,
+            income: income.amount,
+            outgo: outgo.amount,
+            category: category,
+            descriptor: .items(.repeatIDIs(model.repeatID))
         )
         return .result()
     }

--- a/Incomes/Sources/Item/Views/ItemFormView.swift
+++ b/Incomes/Sources/Item/Views/ItemFormView.swift
@@ -230,11 +230,9 @@ private extension ItemFormView {
     func save() {
         do {
             if let item,
-               try GetRepeatItemsCountIntent.perform(
-                (
-                    context: context,
-                    repeatID: item.repeatID
-                )
+               try ItemService.repeatItemsCount(
+                context: context,
+                repeatID: item.repeatID
                ) > 1 {
                 presentToActionSheet()
             } else {
@@ -252,16 +250,14 @@ private extension ItemFormView {
             return
         }
         do {
-            try UpdateItemIntent.perform(
-                (
-                    context: context,
-                    item: entity,
-                    date: date,
-                    content: content,
-                    income: income.decimalValue,
-                    outgo: outgo.decimalValue,
-                    category: category
-                )
+            try ItemService.update(
+                context: context,
+                item: entity,
+                date: date,
+                content: content,
+                income: income.decimalValue,
+                outgo: outgo.decimalValue,
+                category: category
             )
             Haptic.success.impact()
         } catch {
@@ -277,16 +273,14 @@ private extension ItemFormView {
             return
         }
         do {
-            try UpdateFutureItemsIntent.perform(
-                (
-                    context: context,
-                    item: entity,
-                    date: date,
-                    content: content,
-                    income: income.decimalValue,
-                    outgo: outgo.decimalValue,
-                    category: category
-                )
+            try ItemService.updateFuture(
+                context: context,
+                item: entity,
+                date: date,
+                content: content,
+                income: income.decimalValue,
+                outgo: outgo.decimalValue,
+                category: category
             )
             Haptic.success.impact()
         } catch {
@@ -302,16 +296,14 @@ private extension ItemFormView {
             return
         }
         do {
-            try UpdateAllItemsIntent.perform(
-                (
-                    context: context,
-                    item: entity,
-                    date: date,
-                    content: content,
-                    income: income.decimalValue,
-                    outgo: outgo.decimalValue,
-                    category: category
-                )
+            try ItemService.updateAll(
+                context: context,
+                item: entity,
+                date: date,
+                content: content,
+                income: income.decimalValue,
+                outgo: outgo.decimalValue,
+                category: category
             )
             Haptic.success.impact()
         } catch {
@@ -322,16 +314,14 @@ private extension ItemFormView {
 
     func create() {
         do {
-            _ = try CreateItemIntent.perform(
-                (
-                    context: context,
-                    date: date,
-                    content: content,
-                    income: income.decimalValue,
-                    outgo: outgo.decimalValue,
-                    category: category,
-                    repeatCount: repeatSelection
-                )
+            _ = try ItemService.create(
+                context: context,
+                date: date,
+                content: content,
+                income: income.decimalValue,
+                outgo: outgo.decimalValue,
+                category: category,
+                repeatCount: repeatSelection
             )
             Haptic.success.impact()
         } catch {

--- a/Incomes/Sources/Item/Views/RecalculateView.swift
+++ b/Incomes/Sources/Item/Views/RecalculateView.swift
@@ -36,11 +36,9 @@ struct RecalculateView: View {
                     Task {
                         isRecalculating = true
                         do {
-                            try RecalculateItemIntent.perform(
-                                (
-                                    context: context,
-                                    date: selectedDate
-                                )
+                            try ItemService.recalculate(
+                                context: context,
+                                date: selectedDate
                             )
                             try await Task.sleep(for: .seconds(5))
                         } catch {

--- a/Incomes/Sources/Item/Views/YearChartsView.swift
+++ b/Incomes/Sources/Item/Views/YearChartsView.swift
@@ -31,11 +31,9 @@ struct YearChartsView: View {
                 ToolbarAlignmentSpacer()
             }
             ToolbarItem(placement: .status) {
-                if let count = try? GetYearItemsCountIntent.perform(
-                    (
-                        context: context,
-                        date: date
-                    )
+                if let count = try? ItemService.yearItemsCount(
+                    context: context,
+                    date: date
                 ) {
                     Text("\(count) Items")
                         .font(.footnote)

--- a/Incomes/Sources/Main/Intents/OpenIncomesIntent.swift
+++ b/Incomes/Sources/Main/Intents/OpenIncomesIntent.swift
@@ -9,19 +9,12 @@
 import AppIntents
 
 @MainActor
-struct OpenIncomesIntent: AppIntent, IntentPerformer {
-    typealias Input = Void
-    typealias Output = Void
-
+struct OpenIncomesIntent: AppIntent {
     nonisolated static let title: LocalizedStringResource = .init("Open Incomes", table: "AppIntents")
     nonisolated static let openAppWhenRun = true
 
-    static func perform(_: Input) throws -> Output {
-        MainService.open()
-    }
-
     func perform() throws -> some IntentResult {
-        try Self.perform(())
+        MainService.open()
         return .result()
     }
 }

--- a/Incomes/Sources/Notification/Models/NotificationService.swift
+++ b/Incomes/Sources/Notification/Models/NotificationService.swift
@@ -47,7 +47,10 @@ final class NotificationService: NSObject {
     }
 
     func sendTestNotification() {
-        guard let item = try? GetNextItemIntent.perform((context: modelContainer.mainContext, date: .now)) else {
+        guard let item = try? ItemService.nextItem(
+            context: modelContainer.mainContext,
+            date: .now
+        ) else {
             return
         }
 

--- a/Incomes/Sources/Settings/Views/SettingsListView.swift
+++ b/Incomes/Sources/Settings/Views/SettingsListView.swift
@@ -157,8 +157,8 @@ extension SettingsListView: View {
         ) {
             Button(role: .destructive) {
                 do {
-                    try DeleteAllItemsIntent.perform(context)
-                    try DeleteAllTagsIntent.perform(context)
+                    try ItemService.deleteAll(context: context)
+                    try TagService.deleteAll(context: context)
                     Haptic.success.impact()
                 } catch {
                     assertionFailure(error.localizedDescription)
@@ -178,7 +178,7 @@ extension SettingsListView: View {
         }
         .task {
             do {
-                hasDuplicateTags = try GetHasDuplicateTagsIntent.perform(context)
+                hasDuplicateTags = try TagService.hasDuplicates(context: context)
             } catch {
                 assertionFailure(error.localizedDescription)
                 hasDuplicateTags = false

--- a/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteAllTagsIntent.swift
@@ -2,20 +2,13 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct DeleteAllTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
-    typealias Output = Void
-
+struct DeleteAllTagsIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Delete All Tags", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try TagService.deleteAll(context: input)
-    }
-
     func perform() throws -> some IntentResult {
-        try Self.perform(modelContainer.mainContext)
+        try TagService.deleteAll(context: modelContainer.mainContext)
         return .result()
     }
 }

--- a/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
+++ b/Incomes/Sources/Tag/Intents/DeleteTagIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct DeleteTagIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, tag: TagEntity)
-    typealias Output = Void
-
+struct DeleteTagIntent: AppIntent {
     @Parameter(title: "Tag")
     private var tag: TagEntity
 
@@ -13,12 +10,8 @@ struct DeleteTagIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Delete Tag", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try TagService.delete(context: input.context, tag: input.tag)
-    }
-
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, tag: tag))
+        try TagService.delete(context: modelContainer.mainContext, tag: tag)
         return .result()
     }
 }

--- a/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/FindDuplicateTagsIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct FindDuplicateTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, tags: [TagEntity])
-    typealias Output = [TagEntity]
-
+struct FindDuplicateTagsIntent: AppIntent {
     @Parameter(title: "Tags")
     private var tags: [TagEntity]
 
@@ -13,15 +10,11 @@ struct FindDuplicateTagsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Find Duplicate Tags", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try TagService.findDuplicates(
-            context: input.context,
-            tags: input.tags
-        )
-    }
-
     func perform() throws -> some ReturnsValue<[TagEntity]> {
-        let result = try Self.perform((context: modelContainer.mainContext, tags: tags))
+        let result = try TagService.findDuplicates(
+            context: modelContainer.mainContext,
+            tags: tags
+        )
         return .result(value: result)
     }
 }

--- a/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetAllTagsIntent.swift
@@ -2,20 +2,13 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetAllTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
-    typealias Output = [TagEntity]
-
+struct GetAllTagsIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Get All Tags", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try TagService.getAll(context: input)
-    }
-
     func perform() throws -> some ReturnsValue<[TagEntity]> {
-        let tags = try Self.perform(modelContainer.mainContext)
+        let tags = try TagService.getAll(context: modelContainer.mainContext)
         return .result(value: tags)
     }
 }

--- a/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetHasDuplicateTagsIntent.swift
@@ -2,20 +2,13 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetHasDuplicateTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = ModelContext
-    typealias Output = Bool
-
+struct GetHasDuplicateTagsIntent: AppIntent {
     @Dependency private var modelContainer: ModelContainer
 
     nonisolated static let title: LocalizedStringResource = .init("Get Has Duplicate Tags", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try TagService.hasDuplicates(context: input)
-    }
-
     func perform() throws -> some ReturnsValue<Bool> {
-        let result = try Self.perform(modelContainer.mainContext)
+        let result = try TagService.hasDuplicates(context: modelContainer.mainContext)
         return .result(value: result)
     }
 }

--- a/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByIDIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetTagByIDIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, id: String)
-    typealias Output = TagEntity?
-
+struct GetTagByIDIntent: AppIntent {
     @Parameter(title: "Tag ID")
     var id: String
 
@@ -13,16 +10,10 @@ struct GetTagByIDIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Tag By ID", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try TagService.getByID(
-            context: input.context,
-            id: input.id
-        )
-    }
-
     func perform() throws -> some ReturnsValue<TagEntity?> {
-        guard let tagEntity = try Self.perform(
-            (context: modelContainer.mainContext, id: id)
+        guard let tagEntity = try TagService.getByID(
+            context: modelContainer.mainContext,
+            id: id
         ) else {
             return .result(value: nil)
         }

--- a/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
+++ b/Incomes/Sources/Tag/Intents/GetTagByNameIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct GetTagByNameIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, name: String, type: TagType)
-    typealias Output = TagEntity?
-
+struct GetTagByNameIntent: AppIntent {
     @Parameter(title: "Name")
     private var name: String
     @Parameter(title: "Type")
@@ -15,17 +12,11 @@ struct GetTagByNameIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Get Tag By Name", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        return try TagService.getByName(
-            context: input.context,
-            name: input.name,
-            type: input.type
-        )
-    }
-
     func perform() throws -> some ReturnsValue<TagEntity?> {
-        let result = try Self.perform(
-            (context: modelContainer.mainContext, name: name, type: type)
+        let result = try TagService.getByName(
+            context: modelContainer.mainContext,
+            name: name,
+            type: type
         )
         return .result(value: result)
     }

--- a/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/MergeDuplicateTagsIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct MergeDuplicateTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, tags: [TagEntity])
-    typealias Output = Void
-
+struct MergeDuplicateTagsIntent: AppIntent {
     @Parameter(title: "Tags")
     private var tags: [TagEntity]
 
@@ -13,15 +10,11 @@ struct MergeDuplicateTagsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Merge Duplicate Tags", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try TagService.mergeDuplicates(
-            context: input.context,
-            tags: input.tags
-        )
-    }
-
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, tags: tags))
+        try TagService.mergeDuplicates(
+            context: modelContainer.mainContext,
+            tags: tags
+        )
         return .result()
     }
 }

--- a/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
+++ b/Incomes/Sources/Tag/Intents/ResolveDuplicateTagsIntent.swift
@@ -2,10 +2,7 @@ import AppIntents
 import SwiftData
 
 @MainActor
-struct ResolveDuplicateTagsIntent: AppIntent, IntentPerformer {
-    typealias Input = (context: ModelContext, tags: [TagEntity])
-    typealias Output = Void
-
+struct ResolveDuplicateTagsIntent: AppIntent {
     @Parameter(title: "Tags")
     private var tags: [TagEntity]
 
@@ -13,15 +10,11 @@ struct ResolveDuplicateTagsIntent: AppIntent, IntentPerformer {
 
     nonisolated static let title: LocalizedStringResource = .init("Resolve Duplicate Tags", table: "AppIntents")
 
-    static func perform(_ input: Input) throws -> Output {
-        try TagService.resolveDuplicates(
-            context: input.context,
-            tags: input.tags
-        )
-    }
-
     func perform() throws -> some IntentResult {
-        try Self.perform((context: modelContainer.mainContext, tags: tags))
+        try TagService.resolveDuplicates(
+            context: modelContainer.mainContext,
+            tags: tags
+        )
         return .result()
     }
 }

--- a/Incomes/Sources/Tag/Models/TagEntityQuery.swift
+++ b/Incomes/Sources/Tag/Models/TagEntityQuery.swift
@@ -15,17 +15,15 @@ struct TagEntityQuery: EntityStringQuery {
 
     func entities(for identifiers: [TagEntity.ID]) throws -> [TagEntity] {
         try identifiers.compactMap { id in
-            try GetTagByIDIntent.perform(
-                (
-                    context: modelContainer.mainContext,
-                    id: id
-                )
+            try TagService.getByID(
+                context: modelContainer.mainContext,
+                id: id
             )
         }
     }
 
     func entities(matching string: String) throws -> [TagEntity] {
-        let tags = try GetAllTagsIntent.perform(modelContainer.mainContext)
+        let tags = try TagService.getAll(context: modelContainer.mainContext)
         let hiragana = string.applyingTransform(.hiraganaToKatakana, reverse: true).orEmpty
         let katakana = string.applyingTransform(.hiraganaToKatakana, reverse: false).orEmpty
         return [
@@ -47,7 +45,7 @@ struct TagEntityQuery: EntityStringQuery {
     }
 
     func suggestedEntities() throws -> [TagEntity] {
-        let tags = try GetAllTagsIntent.perform(modelContainer.mainContext)
+        let tags = try TagService.getAll(context: modelContainer.mainContext)
         return [
             TagType.year,
             .yearMonth,

--- a/Incomes/Sources/Tag/Views/DuplicateTagListView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagListView.swift
@@ -43,11 +43,9 @@ struct DuplicateTagListView: View {
         ) {
             Button {
                 do {
-                    try ResolveDuplicateTagsIntent.perform(
-                        (
-                            context: context,
-                            tags: selectedTags.compactMap(TagEntity.init)
-                        )
+                    try TagService.resolveDuplicates(
+                        context: context,
+                        tags: selectedTags.compactMap(TagEntity.init)
                     )
                 } catch {
                     assertionFailure(error.localizedDescription)
@@ -73,11 +71,9 @@ struct DuplicateTagListView: View {
     private func buildSection<Header: View>(from tags: [Tag], header: () -> Header) -> some View {
         let duplicates: [Tag]
         do {
-            let entities = try FindDuplicateTagsIntent.perform(
-                (
-                    context: context,
-                    tags: tags.compactMap(TagEntity.init)
-                )
+            let entities = try TagService.findDuplicates(
+                context: context,
+                tags: tags.compactMap(TagEntity.init)
             )
             duplicates = try entities.compactMap { entity in
                 let id = try PersistentIdentifier(base64Encoded: entity.id)

--- a/Incomes/Sources/Tag/Views/DuplicateTagView.swift
+++ b/Incomes/Sources/Tag/Views/DuplicateTagView.swift
@@ -58,11 +58,9 @@ struct DuplicateTagView: View {
         ) {
             Button {
                 do {
-                    try MergeDuplicateTagsIntent.perform(
-                        (
-                            context: context,
-                            tags: tags.compactMap(TagEntity.init)
-                        )
+                    try TagService.mergeDuplicates(
+                        context: context,
+                        tags: tags.compactMap(TagEntity.init)
                     )
                 } catch {
                     assertionFailure(error.localizedDescription)
@@ -86,11 +84,9 @@ struct DuplicateTagView: View {
                     return
                 }
                 do {
-                    try DeleteTagIntent.perform(
-                        (
-                            context: context,
-                            tag: .init(selectedTag)!
-                        )
+                    try TagService.delete(
+                        context: context,
+                        tag: .init(selectedTag)!
                     )
                     self.selectedTag = nil
                     Haptic.success.impact()

--- a/Incomes/Sources/Tag/Views/TagListView.swift
+++ b/Incomes/Sources/Tag/Views/TagListView.swift
@@ -82,10 +82,10 @@ struct TagListView: View {
                     try selectedTags
                         .compactMap(TagEntity.init)
                         .forEach {
-                            try DeleteTagIntent.perform((context: context, tag: $0))
+                            try TagService.delete(context: context, tag: $0)
                         }
                     try items.compactMap(ItemEntity.init).forEach {
-                        try DeleteItemIntent.perform((context: context, item: $0))
+                        try ItemService.delete(context: context, item: $0)
                     }
                     willDeleteTags = .empty
                     Haptic.success.impact()


### PR DESCRIPTION
## Summary
- simplify AppIntents to remove IntentPerformer, typealiases, and static perform
- call ItemService/TagService methods directly throughout the app

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6898389eecf48320ab2da2f44efee22d