### PR TITLE
Add missing translations to string catalogs

### DIFF
--- a/Incomes/Resources/AppIntents.xcstrings
+++ b/Incomes/Resources/AppIntents.xcstrings
@@ -110,7 +110,98 @@
       }
     },
     "%lld Tags" : {
-
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld Tag"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld Tags"
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld etiqueta"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld etiquetas"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld étiquette"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld étiquettes"
+                }
+              }
+            }
+          }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld タグ"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld タグ"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 个标签"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld 个标签"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "Create and Show Item" : {
       "localizations" : {
@@ -181,7 +272,38 @@
       }
     },
     "Delete All Items" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete All Items"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar todos los elementos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer tous les éléments"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのアイテムを削除"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除所有项目"
+          }
+        }
+      }
     },
     "Delete All Tags" : {
       "localizations" : {
@@ -218,7 +340,38 @@
       }
     },
     "Delete Item" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Item"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar elemento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer l'élément"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイテムを削除"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除项目"
+          }
+        }
+      }
     },
     "Delete Tag" : {
       "localizations" : {
@@ -255,16 +408,40 @@
       }
     },
     "Find Duplicate Tags" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Find Duplicate Tags" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Buscar etiquetas duplicadas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Trouver les étiquettes en double" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "重複タグを検索" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "查找重复标签" } }
+      }
     },
     "Get All Items Count" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Get All Items Count" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Obtener el conteo de todos los elementos" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Obtenir le nombre de tous les éléments" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "すべてのアイテム数を取得" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "获取所有项目的数量" } }
+      }
     },
     "Get All Tags" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Get All Tags" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Obtener todas las etiquetas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Obtenir toutes les étiquettes" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "すべてのタグを取得" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "获取所有标签" } }
+      }
     },
     "Get Has Duplicate Tags" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Get Has Duplicate Tags" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Obtener si hay etiquetas duplicadas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Obtenir s'il existe des étiquettes en double" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "重複タグがあるか取得" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "获取是否存在重复标签" } }
+      }
     },
     "Get Items" : {
       "localizations" : {
@@ -641,16 +818,40 @@
       }
     },
     "Get Repeat Items Count" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Get Repeat Items Count" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Obtener el conteo de elementos repetidos" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Obtenir le nombre d'éléments répétitifs" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "繰り返しアイテム数を取得" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "获取重复项目的数量" } }
+      }
     },
     "Get Tag By ID" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Get Tag By ID" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Obtener etiqueta por ID" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Obtenir l'étiquette par ID" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "IDでタグを取得" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "按ID获取标签" } }
+      }
     },
     "Get Tag By Name" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Get Tag By Name" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Obtener etiqueta por nombre" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Obtenir l'étiquette par nom" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前でタグを取得" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "按名称获取标签" } }
+      }
     },
     "Get Year Items Count" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Get Year Items Count" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Obtener el conteo de elementos del año" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Obtenir le nombre d'éléments de l'année" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "年間アイテム数を取得" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "获取年度项目数量" } }
+      }
     },
     "Income: %@, Outgo: %@" : {
       "localizations" : {
@@ -687,7 +888,13 @@
       }
     },
     "Infer Item Form" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Infer Item Form" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Inferir formulario de elemento" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Déduire le formulaire de l'élément" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アイテムフォームを推測" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "推断项目表单" } }
+      }
     },
     "Item" : {
       "localizations" : {
@@ -724,7 +931,13 @@
       }
     },
     "Merge Duplicate Tags" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Merge Duplicate Tags" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Combinar etiquetas duplicadas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Fusionner les étiquettes en double" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "重複タグを統合" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "合并重复标签" } }
+      }
     },
     "Not Found" : {
       "localizations" : {
@@ -795,7 +1008,13 @@
       }
     },
     "Recalculate Item" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Recalculate Item" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Recalcular elemento" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Recalculer l'élément" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アイテムを再計算" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "重新计算项目" } }
+      }
     },
     "Recent Item" : {
       "localizations" : {
@@ -854,7 +1073,13 @@
       }
     },
     "Resolve Duplicate Tags" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Resolve Duplicate Tags" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Resolver etiquetas duplicadas" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Résoudre les étiquettes en double" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "重複タグを解決" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "解决重复标签" } }
+      }
     },
     "Show Charts" : {
       "localizations" : {
@@ -1229,7 +1454,13 @@
       }
     },
     "Tag" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Tag" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Etiqueta" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Étiquette" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "タグ" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "标签" } }
+      }
     },
     "This Month’s Charts" : {
       "localizations" : {
@@ -1344,16 +1575,40 @@
       }
     },
     "Update All Items" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Update All Items" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Actualizar todos los elementos" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mettre à jour tous les éléments" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "すべてのアイテムを更新" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更新所有项目" } }
+      }
     },
     "Update Future Items" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Update Future Items" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Actualizar elementos futuros" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mettre à jour les éléments futurs" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "今後のアイテムを更新" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更新未来项目" } }
+      }
     },
     "Update Item" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Update Item" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Actualizar elemento" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mettre à jour l'élément" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アイテムを更新" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更新项目" } }
+      }
     },
     "Update Repeating Items" : {
-
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Update Repeating Items" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Actualizar elementos repetidos" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mettre à jour les éléments récurrents" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "繰り返しアイテムを更新" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "更新重复项目" } }
+      }
     }
   },
   "version" : "1.0"

--- a/Incomes/Resources/Localizable.xcstrings
+++ b/Incomes/Resources/Localizable.xcstrings
@@ -2,7 +2,15 @@
   "sourceLanguage" : "en",
   "strings" : {
     "%@" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        }
+      },
+      "shouldTranslate" : false
     },
     "%@ - A payment of %@ is due on %@." : {
       "localizations" : {
@@ -728,7 +736,38 @@
       }
     },
     "Camera" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Camera"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cámara"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appareil photo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カメラ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相机"
+          }
+        }
+      }
     },
     "Cancel" : {
       "localizations" : {
@@ -901,7 +940,38 @@
       }
     },
     "Content is empty" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Content is empty"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El contenido está vacío"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le contenu est vide"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内容が空です"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内容为空"
+          }
+        }
+      }
     },
     "Create" : {
       "localizations" : {
@@ -1482,7 +1552,38 @@
       }
     },
     "Error" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラー"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "错误"
+          }
+        }
+      }
     },
     "Explore with Sample Items" : {
       "localizations" : {
@@ -1519,7 +1620,38 @@
       }
     },
     "Failed to convert item entity" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to convert item entity"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo convertir la entidad del elemento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la conversion de l'entité de l'élément"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイテムエンティティの変換に失敗しました"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法转换项目实体"
+          }
+        }
+      }
     },
     "Home" : {
       "localizations" : {
@@ -1760,13 +1892,106 @@
       }
     },
     "Item" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Item"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elemento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élément"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイテム"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "项目"
+          }
+        }
+      }
     },
     "Item Form Inference" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Item Form Inference"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inferencia de formulario de elemento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inférence du formulaire d'élément"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイテムフォームの推測"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "项目表单推断"
+          }
+        }
+      }
     },
     "Item not found" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Item not found"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elemento no encontrado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élément introuvable"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アイテムが見つかりません"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到项目"
+          }
+        }
+      }
     },
     "Items" : {
       "localizations" : {
@@ -2517,7 +2742,38 @@
       }
     },
     "Photo Library" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Photo Library"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biblioteca de fotos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Photothèque"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "写真ライブラリ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "照片图库"
+          }
+        }
+      }
     },
     "Please update Incomes to the latest version to continue using it." : {
       "localizations" : {
@@ -2758,7 +3014,38 @@
       }
     },
     "Repeat ID" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repeat ID"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de repetición"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de répétition"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繰り返しID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重复ID"
+          }
+        }
+      }
     },
     "RepeatID" : {
       "localizations" : {
@@ -3442,16 +3729,140 @@
       }
     },
     "Tag" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiqueta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Étiquette"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标签"
+          }
+        }
+      }
     },
     "Tag ID" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag ID"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de etiqueta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID d'étiquette"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标签ID"
+          }
+        }
+      }
     },
     "Tag not found" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag not found"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiqueta no encontrada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Étiquette introuvable"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグが見つかりません"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到标签"
+          }
+        }
+      }
     },
     "Tag Type" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag Type"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de etiqueta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type d'étiquette"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグタイプ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标签类型"
+          }
+        }
+      }
     },
     "Tags" : {
       "localizations" : {
@@ -3556,7 +3967,38 @@
       }
     },
     "Text" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texte"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本"
+          }
+        }
+      }
     },
     "This is a repeating item." : {
       "localizations" : {
@@ -4035,7 +4477,38 @@
       }
     },
     "Year/Month" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Year/Month"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Año/Mes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Année/Mois"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年/月"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "年/月"
+          }
+        }
+      }
     },
     "YearMonth" : {
       "localizations" : {


### PR DESCRIPTION
## Summary
- fill untranslated entries in Localizable.xcstrings
- complete AppIntents.xcstrings translations for tag and item actions

## Testing
- `xcodebuild -project Incomes.xcodeproj -scheme Incomes -destination 'platform=iOS Simulator,OS=latest' test` *(fails: command not found)*
- `xcodebuild -project Incomes.xcodeproj -scheme IncomesLibrary -destination 'platform=iOS Simulator,OS=latest' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32f9ae1b8832095adfe57c6bf424c