### PR TITLE
test: add coverage for duplicate tags and date edge cases

### DIFF
--- a/IncomesLibrary/Tests/Default/TagServiceTests.swift
+++ b/IncomesLibrary/Tests/Default/TagServiceTests.swift
@@ -132,6 +132,35 @@ struct TagServiceTests {
     }
 
     @Test
+    func mergeDuplicates_does_not_leave_parent_duplicated_on_items() throws {
+        let item = try Item.createIgnoringDuplicates(
+            context: context,
+            date: .now,
+            content: "content",
+            income: .zero,
+            outgo: .zero,
+            category: "",
+            repeatID: .init()
+        )
+        let parent = try #require(
+            item.tags?.first { tag in
+                tag.type == .content
+            }
+        )
+        let duplicate = try Tag.createIgnoringDuplicates(
+            context: context,
+            name: parent.name,
+            type: .content
+        )
+        item.modify(tags: [parent, duplicate])
+        try TagService.mergeDuplicates(tags: [parent, duplicate])
+        let contentTags = item.tags?.filter { tag in
+            tag.id == parent.id
+        }
+        #expect(contentTags?.count == 1)
+    }
+
+    @Test
     func resolveDuplicates_removes_all_duplicates() throws {
         let tag1 = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)
         _ = try Tag.createIgnoringDuplicates(context: context, name: "A", type: .year)

--- a/IncomesLibrary/Tests/TimeZone/ItemServiceTest.swift
+++ b/IncomesLibrary/Tests/TimeZone/ItemServiceTest.swift
@@ -247,6 +247,28 @@ struct ItemServiceTest {
         #expect(Set(items.map(\.category?.name)).count == 1)
     }
 
+    @Test("create with end-of-month date generates all repeating items", arguments: timeZones)
+    func createEndOfMonthRepeatingItems(_ timeZone: TimeZone) throws {
+        NSTimeZone.default = timeZone
+
+        _ = try createItem(
+            date: isoDate("2024-01-31T00:00:00Z"),
+            content: "EndMonth",
+            income: 100,
+            outgo: 0,
+            category: "Test",
+            repeatCount: 3
+        )
+        let items = try context.fetch(.items(.all)).sorted { first, second in
+            first.utcDate < second.utcDate
+        }
+        #expect(items.count == 3)
+        let months = items.map { item in
+            item.utcDate.stringValueWithoutLocale(.yyyyMM)
+        }
+        #expect(months == ["2024-01", "2024-02", "2024-03"])
+    }
+
     @Test("create stores date near midnight UTC correctly", arguments: timeZones)
     func createWithMidnightBoundary(_ timeZone: TimeZone) throws {
         NSTimeZone.default = timeZone

--- a/IncomesTests/Sources/Default/ModelContainerInitializationTests.swift
+++ b/IncomesTests/Sources/Default/ModelContainerInitializationTests.swift
@@ -1,0 +1,16 @@
+@testable import Incomes
+import SwiftData
+import Testing
+
+struct ModelContainerInitializationTests {
+    @Test
+    func initWithInvalidURLThrows() {
+        let url: URL = .init(fileURLWithPath: "/root/invalid/dir/store.sqlite")
+        #expect(throws: any Error.self) {
+            try ModelContainer(
+                for: Item.self,
+                configurations: .init(url: url)
+            )
+        }
+    }
+}

--- a/IncomesTests/Sources/Default/ModelContainerInitializationTests.swift
+++ b/IncomesTests/Sources/Default/ModelContainerInitializationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import Incomes
 import SwiftData
 import Testing
@@ -6,7 +7,7 @@ struct ModelContainerInitializationTests {
     @Test
     func initWithInvalidURLThrows() {
         let url: URL = .init(fileURLWithPath: "/root/invalid/dir/store.sqlite")
-        #expect(throws: any Error.self) {
+        #expect(throws: Error.self) {
             try ModelContainer(
                 for: Item.self,
                 configurations: .init(url: url)


### PR DESCRIPTION
## Summary
- add test ensuring tag merging does not leave duplicated parent tags
- add test verifying end-of-month repeating item creation
- add test covering model container initialization failure with invalid URL

## Testing
- `pre-commit run --files IncomesLibrary/Tests/Default/TagServiceTests.swift IncomesLibrary/Tests/TimeZone/ItemServiceTest.swift IncomesTests/Sources/Default/ModelContainerInitializationTests.swift`
- `xcodebuild -list -project Incomes.xcodeproj`
- `xcodebuild -project Incomes.xcodeproj -scheme Incomes -destination 'platform=iOS Simulator,OS=latest' test`


------
https://chatgpt.com/codex/tasks/task_e_68c6687c711c8320b861c394930f98da