### PR TITLE
docs: refresh readme and landing page

### DIFF
--- a/.github/pages/index.md
+++ b/.github/pages/index.md
@@ -4,23 +4,33 @@
   <img src="../../Incomes/Resources/Assets.xcassets/AppIcon.appiconset/AppIcon.png" width="120" alt="Incomes app icon" />
 </p>
 
-**A modern budget manager for iOS built with SwiftUI.**
+**A modern budget manager built with SwiftUI, SwiftData and the latest Apple frameworks.**
 
 [![Download on the App Store](https://linkmaker.itunes.apple.com/assets/shared/badges/en-us/appstore-lrg.svg)](https://apps.apple.com/app/id1584472982)
 
-## Key Features
+## Highlights
 
-- 📊 **Quickly capture** incomes and outgoings with categories
-- ⏰ **Manage recurring items** and keep your balance up to date
-- 🔍 **Search and filter** by tags or categories
-- ☁️ **iCloud sync** for subscribers
-- 🔔 **Custom notifications** for upcoming payments
-- ⚙️ **Built with SwiftUI and SwiftData**
+- 📸 **Intelligent capture** – scan receipts with VisionKit, dictate with SpeechKit or import photos, then let Foundation Models infer the form for you.
+- 🧮 **Powerful logging** – handle recurring items, tags and balance calculations with one tap.
+- 📈 **Search & insights** – drill into months and categories with Swift Charts and rich filters.
+- 🔔 **Stay ahead** – fine-tune push reminders, lead times and thresholds for upcoming payments.
+- 🌐 **Premium sync** – unlock iCloud syncing, ad removal and StoreKit-managed subscriptions.
 
-## Getting Started
+## Platforms
 
-Clone the repository and open `Incomes.xcodeproj` with Xcode 15 or later. Run the **Incomes** scheme on an iOS 17.0 or later device.
+- **iPhone & iPad** – full budgeting experience with charts, Siri Shortcuts and App Intents.
+- **Apple Watch** – glanceable upcoming payments plus subscription management on the wrist.
+- **Widgets & Live Activities** – balance, upcoming and control widgets keep finances visible in StandBy and on the Home Screen.
 
-The app loads `.config.json` from GitHub at launch to determine if an update is required.
+## Build from source
 
-[Privacy Policy](privacy.html)
+1. Clone the repository.
+2. Create `Incomes/Configurations/Secret.swift` (and mirror it to `Watch/Configurations`) with your App Group, StoreKit product ID and AdMob unit IDs.
+3. Open `Incomes.xcodeproj` in Xcode 16 or later and run the **Incomes** scheme on an iOS 18 simulator or device.
+
+See the [README](../../README.md) for detailed setup instructions, testing commands and remote configuration notes.
+
+## Links
+
+- [App Store](https://apps.apple.com/app/id1584472982)
+- [Privacy Policy](privacy.html)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,95 @@
 # Incomes
 
-Incomes is a Cupertino style budget manager for iOS.
+Incomes is a Cupertino-style budget manager that keeps your finances organised across iPhone, Apple Watch and widgets.
 
-[App Store](https://apps.apple.com/app/id1584472982)
+[Download on the App Store](https://apps.apple.com/app/id1584472982)
 
 ## Features
 
-- Quickly record incomes and outgoings with categories
-- Manage recurring items and track balance
-- Search items and filter by tags or categories
-- Optional iCloud sync for subscribers
-- Notification reminders for upcoming payments
-- Customizable currency and push notification settings
-- Built with SwiftUI and SwiftData
+### Intelligent capture
 
-## Building
+- Capture receipts or statements from the photo library, camera or microphone and let on-device speech recognition and Vision extract the text automatically.
+- Use Foundation Models–powered inference to pre-fill the item form with dates, categories and amounts in the user’s locale.
 
-Open `Incomes.xcodeproj` with Xcode 15 or later and run the **Incomes** scheme on an iOS 17.0 or later device.
+### Fast logging and organisation
 
-The app loads `.config.json` from GitHub at launch to determine if an update is required.
+- Log incomes and outgoings with repeat counts, categories and contextual shortcuts straight from the form view.
+- Automatically create future occurrences for recurring payments and keep balances accurate through the shared data layer.
+- Resolve duplicate tags, recalculate balances and clean up tutorial data directly from Settings.
+
+### Search and insights
+
+- Search by content, category or numeric ranges with menu-driven filters to drill into any time period.
+- Browse yearly summaries, detailed charts and profit breakdowns powered by Swift Charts and SwiftData predicates.
+
+### Stay on schedule
+
+- Configure rich push-notification rules, including thresholds, lead times, delivery windows and test notifications.
+- Automatic upcoming-payment reminders keep badge counts and delivered notifications in sync across devices.
+
+### Available everywhere
+
+- A collection of widgets for balance snapshots, upcoming items, monthly breakdowns, control widgets and Live Activities keeps data on the Home Screen and StandBy.
+- The watchOS companion lists upcoming payments, manages subscriptions and mirrors notification settings right from the wrist.
+
+### Premium and sync options
+
+- Subscribers unlock iCloud syncing, remove ads and manage their plan through StoreKit 2 and the in-app paywall.
+- Non-subscribers see Google Mobile Ads placements that are shared across the app and widgets.
+- A remote configuration feed allows urgent update requirements to be enforced without shipping a new build.
+
+## Targets and shared modules
+
+- **Incomes** – the main iOS app built with SwiftUI and SwiftData, including CloudKit-backed syncing when iCloud is enabled.
+- **Watch** – a watchOS companion that uses the same SwiftData store and StoreKit subscription logic.
+- **Widgets** – WidgetKit bundle providing multiple Home Screen widgets, Live Activities and control widgets.
+- **IncomesLibrary** – a reusable module containing the data model, business logic, migration utilities and notification planners shared across all targets.
+
+External packages such as StoreKitWrapper, GoogleMobileAdsWrapper, PhotosUI, SpeechWrapper and VisionKit are used to integrate subscriptions, advertising and media capture.
+
+## Getting started
+
+### Requirements
+
+- Xcode 16 (iOS 18 / watchOS 11 SDKs) or later
+- An Apple Developer account for configuring App Group, iCloud and StoreKit entitlements
+
+### Project setup
+
+1. Clone the repository.
+2. Create `Incomes/Configurations/Secret.swift` (and copy it to `Watch/Configurations/Secret.swift`) containing your identifiers:
+
+   ```swift
+   enum Secret {
+       static let groupID = "group.com.example.incomes"
+       static let productID = "com.example.incomes.premium"
+       static let admobNativeID = "ca-app-pub-xxxxxxxxxxxxxxxx/yyyyyyyyyy"
+       static let admobNativeIDDev = "ca-app-pub-3940256099942544/3986624511" // Google test ID
+   }
+   ```
+
+   Xcode Cloud retrieves the same file from the `SECRET_BASE64` environment variable during CI builds.
+3. Open `Incomes.xcodeproj` in Xcode and select the **Incomes** scheme.
+4. Run on an iOS 18 simulator or device. Enable the **IncomesWatch** and **Widgets** schemes if you want to test companion experiences.
+
+### Remote configuration
+
+The app downloads `.config.json` from the `main` branch on GitHub at launch to learn about required versions or feature flags. Host your own file if you fork the project.
+
+### Testing
+
+Run the shared test suites from macOS using Xcode command line tools:
+
+```sh
+xcodebuild -project Incomes.xcodeproj -scheme Incomes \
+  -destination 'platform=iOS Simulator,OS=latest' test
+
+xcodebuild -project Incomes.xcodeproj -scheme IncomesLibrary \
+  -destination 'platform=iOS Simulator,OS=latest' test
+```
+
+## Links
+
+- [App Store](https://apps.apple.com/app/id1584472982)
+- [Privacy Policy](.github/pages/privacy.md)
 


### PR DESCRIPTION
## Summary
- expand the README with updated feature highlights, target/module descriptions, setup instructions, and testing guidance
- refresh the GitHub Pages landing page to match the new messaging and build steps

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c96aaa6f0c83209be4fc8193f754bf