### PR TITLE
Update agent documentation guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+This document outlines the expectations and tooling references for contributors working on the Incomes project.
+
 ## Coding Guidelines for Codex Agents
 
 This document defines the minimum coding standards for implementing Agents in the Codex project.
@@ -12,7 +14,7 @@ All Swift code must comply with the SwiftLint rules defined in the project.
 
 ### Avoid abbreviated variable names
 
-Do not use unclear abbreviations such as `res`, `img`, or `btn`.  
+Do not use unclear abbreviations such as `res`, `img`, or `btn`.
 Use descriptive and explicit names like `result`, `image`, or `button`.
 
 ### Use `.init(...)` when the return type is explicitly known
@@ -21,21 +23,23 @@ In contexts where the return type is clear (e.g., function return values, comput
 
 #### Examples
 
+##### Preferred
+
 ```swift
 var user: User {
-  .init(name: "Alice") // ✅ OK: return type is explicitly User
+    .init(name: "Alice") // ✅ Return context explicitly typed as User
 }
-
-func makeUser() -> User {
-  .init(name: "Bob") // ✅ OK
-}
-
-let user = User(name: "Carol") // ❌ Less preferred when type is not obvious
 ```
 
-### Multiline control‑flow and trailing‑closure formatting
+##### Not preferred
 
-Avoid single‑line bodies for **any** control‑flow statement (`if`, `guard`, `while`, `switch`, etc.) or trailing closures.  
+```swift
+let user = .init(name: "Carol") // ❌ Local variable lacks an explicit type declaration
+```
+
+### Multiline control-flow and trailing-closure formatting
+
+Avoid single-line bodies for **any** control-flow statement (`if`, `guard`, `while`, `switch`, etc.) or trailing closures.
 Always place the body on its own indented line between braces to improve readability and make diffs cleaner.
 
 #### Preferred
@@ -66,7 +70,7 @@ tasks.filter { $0.isCompleted }
 
 ### Follow markdownlint rules for Markdown files
 
-All Markdown documents must conform to the rules defined at:  
+All Markdown documents must conform to the rules defined at:
 https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 
 ## Project-wide Conventions
@@ -90,11 +94,13 @@ Use these minimal, reliable commands to build and run tests via Xcode. They avoi
 These scripts standardize invocation and keep artifacts under `build/` to avoid permission issues.
 
 - List schemes:
+
   ```sh
   bash ci_scripts/xcodebuild_list_schemes.sh
   ```
 
 - Run app tests (Incomes scheme):
+
   ```sh
   DERIVED_DATA_PATH=build/DerivedData \
   RESULTS_DIR=build \
@@ -102,8 +108,9 @@ These scripts standardize invocation and keep artifacts under `build/` to avoid 
   ```
 
 - Run library tests (IncomesLibrary scheme):
+
   ```sh
-  # Note: IncomesLibrary is iOS-only. Do not use `swift test`.
+  # Note: IncomesLibrary is iOS-only. Do not use `swift test`. `xcodebuild` is required because the scheme depends on the iOS Simulator runtime that `swift test` cannot drive.
   DERIVED_DATA_PATH=build/DerivedData \
   RESULTS_DIR=build \
   bash ci_scripts/xcodebuild_test_scheme.sh IncomesLibrary
@@ -112,6 +119,7 @@ These scripts standardize invocation and keep artifacts under `build/` to avoid 
 - Options:
   - Prefer a specific simulator: set `UDID=<simulator-udid>`
   - Concise logs when available: pass `xcpretty` as the second arg
+
     ```sh
     bash ci_scripts/xcodebuild_test_scheme.sh Incomes xcpretty
     ```
@@ -128,19 +136,22 @@ These scripts standardize invocation and keep artifacts under `build/` to avoid 
 - Equivalent raw commands (if you prefer `xcodebuild` directly):
 
 - Run app tests (auto-pick latest iOS Simulator):
+
   ```sh
   xcodebuild -project Incomes.xcodeproj -scheme Incomes \
     -destination 'platform=iOS Simulator,OS=latest' test
   ```
 
 - Run library tests (via Xcode scheme on iOS Simulator):
+
   ```sh
-  # Note: IncomesLibrary is iOS-only. Do not use `swift test`.
+  # Note: IncomesLibrary is iOS-only. Do not use `swift test`. `xcodebuild` is required because the scheme depends on the iOS Simulator runtime that `swift test` cannot drive.
   xcodebuild -project Incomes.xcodeproj -scheme IncomesLibrary \
     -destination 'platform=iOS Simulator,OS=latest' test
   ```
 
 - If destination resolution fails, target a specific simulator UDID:
+
   ```sh
   # Prefer a booted simulator
   UDID=$(xcrun simctl list devices | awk '/Booted/ {print $4; exit}' | tr -d '()')


### PR DESCRIPTION
## Summary
- clarify the purpose of the agent guidelines document and expand the `.init(...)` examples
- refresh control-flow formatting guidance and add markdownlint-friendly spacing
- explain why iOS-only schemes rely on xcodebuild while preserving existing test commands

## Testing
- not run (not needed for documentation changes)

------
https://chatgpt.com/codex/tasks/task_e_68d22acef8ec832094533872a14c9f91