### PR TITLE
[codex] Split sample data localization catalog

### DIFF
--- a/Incomes/Sources/Features/Debug/Models/IncomesSampleData.swift
+++ b/Incomes/Sources/Features/Debug/Models/IncomesSampleData.swift
@@ -79,26 +79,6 @@ extension IncomesSampleData {
     static func prepareDuplicateTagPreviewData(
         in context: ModelContext
     ) throws {
-        let previewDuplicateCount = 2
-        let duplicateCategoryName = String(localized: "Credit")
-        let items = try ItemQueryOperations.items(context: context)
-        let sourceItems = items.filter { item in
-            item.category?.name == duplicateCategoryName
-        }
-
-        guard sourceItems.count >= previewDuplicateCount else {
-            return
-        }
-
-        for item in sourceItems.prefix(previewDuplicateCount) {
-            let duplicateTag = Tag.createIgnoringDuplicates(
-                context: context,
-                name: duplicateCategoryName,
-                type: .category
-            )
-            var tags = item.tags ?? []
-            tags.append(duplicateTag)
-            item.modify(tags: tags)
-        }
+        try SampleDataOperations.seedDuplicateTagPreviewData(context: context)
     }
 }

--- a/IncomesLibrary/Resources/SampleData.xcstrings
+++ b/IncomesLibrary/Resources/SampleData.xcstrings
@@ -1,614 +1,614 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "%lld groups / %lld items / %lld skipped" : {
+    "Advertising revenue" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld groups / %2$lld items / %3$lld skipped"
+            "value" : "Ad revenue"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld grupos / %2$lld elementos / %3$lld omitidos"
+            "value" : "Ingresos por anuncios"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld groupes / %2$lld éléments / %3$lld ignorés"
+            "value" : "Revenus publicitaires"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lldグループ / %2$lld項目 / %3$lld件スキップ"
+            "value" : "広告収入"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$lld 个分组 / %2$lld 个项目 / 已跳过 %3$lld 个"
+            "value" : "广告收入"
           }
         }
       }
     },
-    "Invalid month requested for summary generation." : {
+    "Apple card" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Choose a valid month to generate a summary."
+            "value" : "Apple Card"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Elige un mes válido para generar un resumen."
+            "value" : "Tarjeta Apple"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Choisissez un mois valide pour générer un résumé."
+            "value" : "Carte Apple"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "サマリーを生成するには有効な月を選択してください。"
+            "value" : "Appleカード"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请选择有效月份来生成摘要。"
+            "value" : "Apple 卡"
           }
         }
       }
     },
-    "Compared with the previous month, %@." : {
+    "Car" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compared with the previous month, %1$@."
+            "value" : "Car loan"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En comparación con el mes anterior, %1$@."
+            "value" : "Préstamo del coche"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Par rapport au mois précédent, %1$@."
+            "value" : "Crédit auto"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前月と比べると、%1$@。"
+            "value" : "自動車ローン"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "与上月相比，%1$@。"
+            "value" : "车贷"
           }
         }
       }
     },
-    "%@ income decreased" : {
+    "Credit" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ income decreased"
+            "value" : "Credit card"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "disminuyeron los ingresos de %1$@"
+            "value" : "Tarjeta de crédito"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "les revenus de %1$@ ont diminué"
+            "value" : "Carte de crédit"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@の収入が減りました"
+            "value" : "クレジットカード"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@收入减少"
+            "value" : "信用卡"
           }
         }
       }
     },
-    "%@ income increased" : {
+    "Food" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ income increased"
+            "value" : "Food & dining"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "aumentaron los ingresos de %1$@"
+            "value" : "Comida y restaurantes"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "les revenus de %1$@ ont augmenté"
+            "value" : "Repas et courses"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@の収入が増えました"
+            "value" : "食費・外食"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@收入增加"
+            "value" : "餐饮"
           }
         }
       }
     },
-    "There is not enough previous-month data for a reliable comparison." : {
+    "Grocery" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "There is not enough previous-month data for a reliable comparison."
+            "value" : "Groceries"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No hay suficientes datos del mes anterior para una comparación fiable."
+            "value" : "Supermercado"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les données du mois précédent sont insuffisantes pour une comparaison fiable."
+            "value" : "Courses"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前月との比較に十分なデータはありません。"
+            "value" : "食料品"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "没有足够的上月数据进行可靠比较。"
+            "value" : "食品杂货"
           }
         }
       }
     },
-    "There were no major category-level changes from the previous month." : {
+    "House" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "There were no major category-level changes from the previous month."
+            "value" : "Mortgage"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No hubo cambios importantes por categoría respecto al mes anterior."
+            "value" : "Hipoteca"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aucun changement important par catégorie par rapport au mois précédent."
+            "value" : "Prêt immobilier"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "前月と比べて大きなカテゴリ変化はありませんでした。"
+            "value" : "住宅ローン"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "与上月相比，类别层面没有明显变化。"
+            "value" : "房贷"
           }
         }
       }
     },
-    "%@ spending decreased" : {
+    "Housing" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ spending decreased"
+            "value" : "Housing"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "disminuyó el gasto en %1$@"
+            "value" : "Vivienda"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "les dépenses de %1$@ ont diminué"
+            "value" : "Logement"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@の支出が減りました"
+            "value" : "住宅"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@支出减少"
+            "value" : "住房"
           }
         }
       }
     },
-    "%@ spending increased" : {
+    "Insurance" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ spending increased"
+            "value" : "Insurance premium"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "aumentó el gasto en %1$@"
+            "value" : "Prima de seguro"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "les dépenses de %1$@ ont augmenté"
+            "value" : "Prime d’assurance"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@の支出が増えました"
+            "value" : "保険料"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@支出增加"
+            "value" : "保险费"
           }
         }
       }
     },
-    "Income for %@ was %@. Outgo was %@, and the net result was %@. %@" : {
+    "Lemon card" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Income for %1$@ was %2$@. Outgo was %3$@, and the net result was %4$@. %5$@"
+            "value" : "Lemon card"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Los ingresos de %1$@ fueron %2$@. Los gastos fueron %3$@, y el resultado neto fue %4$@. %5$@"
+            "value" : "Tarjeta limón"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les revenus de %1$@ étaient de %2$@. Les dépenses étaient de %3$@, pour un solde net de %4$@. %5$@"
+            "value" : "Carte citron"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@の収入は%2$@でした。支出は%3$@で、収支は%4$@でした。%5$@"
+            "value" : "レモンカード"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@的收入为%2$@。支出为%3$@，净结果为%4$@。%5$@"
+            "value" : "柠檬卡"
           }
         }
       }
     },
-    "On-device item inference is currently unavailable." : {
+    "Loan" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Item suggestions are currently unavailable on this device."
+            "value" : "Loans"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Las sugerencias de elementos no están disponibles en este dispositivo en este momento."
+            "value" : "Préstamos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les suggestions d’éléments ne sont pas disponibles sur cet appareil pour le moment."
+            "value" : "Prêts"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このデバイスでは現在、項目の候補を利用できません。"
+            "value" : "ローン"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此设备目前无法使用项目建议。"
+            "value" : "贷款"
           }
         }
       }
     },
-    "On-device item inference is unavailable in the current language." : {
+    "Orange card" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Item suggestions are not available for the current language."
+            "value" : "Orange card"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Las sugerencias de elementos no están disponibles para el idioma actual."
+            "value" : "Tarjeta naranja"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les suggestions d’éléments ne sont pas disponibles dans la langue actuelle."
+            "value" : "Carte orange"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "現在の言語では項目の候補を利用できません。"
+            "value" : "オレンジカード"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当前语言无法使用项目建议。"
+            "value" : "橙子卡"
           }
         }
       }
     },
-    "On-device monthly summaries are currently unavailable." : {
+    "Payday" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Monthly summaries are currently unavailable on this device."
+            "value" : "Paycheck"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Los resúmenes mensuales no están disponibles en este dispositivo en este momento."
+            "value" : "Nómina"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les résumés mensuels ne sont pas disponibles sur cet appareil pour le moment."
+            "value" : "Paie"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "このデバイスでは現在、月次サマリーを利用できません。"
+            "value" : "給与"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "此设备目前无法使用月度摘要。"
+            "value" : "工资入账"
           }
         }
       }
     },
-    "On-device monthly summaries are unavailable in the current language." : {
+    "Pension" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Monthly summaries are not available for the current language."
+            "value" : "Pension contribution"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Los resúmenes mensuales no están disponibles para el idioma actual."
+            "value" : "Aporte a la pensión"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les résumés mensuels ne sont pas disponibles dans la langue actuelle."
+            "value" : "Cotisation retraite"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "現在の言語では月次サマリーを利用できません。"
+            "value" : "年金保険料"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当前语言无法使用月度摘要。"
+            "value" : "养老金缴费"
           }
         }
       }
     },
-    "Others" : {
+    "Rent" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Other"
+            "value" : "Rent"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Otros"
+            "value" : "Alquiler"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Autres"
+            "value" : "Loyer"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "その他"
+            "value" : "家賃"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "其他"
+            "value" : "房租"
           }
         }
       }
     },
-    "System" : {
+    "Salary" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "System"
+            "value" : "Salary"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sistema"
+            "value" : "Salario"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Système"
+            "value" : "Salaire"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "システム"
+            "value" : "給料"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "系统"
+            "value" : "工资"
           }
         }
       }
     },
-    "Unable to generate the monthly summary." : {
+    "Sample Data" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unable to generate monthly summary."
+            "value" : "Sample data"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudo generar el resumen mensual."
+            "value" : "Datos de muestra"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Impossible de générer le résumé mensuel."
+            "value" : "Données d’exemple"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "月次サマリーを生成できませんでした。"
+            "value" : "サンプルデータ"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法生成月度摘要。"
+            "value" : "示例数据"
           }
         }
       }
     },
-    "Unable to infer item details." : {
+    "Tax" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unable to fill in item details."
+            "value" : "Taxes & insurance"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudieron completar los detalles del elemento."
+            "value" : "Impuestos y seguros"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Impossible de compléter les détails de l’élément."
+            "value" : "Impôts et assurances"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "項目の詳細を入力できませんでした。"
+            "value" : "税金・保険"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法补全项目详细信息。"
+            "value" : "税费和保险"
           }
         }
       }

--- a/IncomesLibrary/Sources/Item/ItemSampleDataSeeder+PreviewSupport.swift
+++ b/IncomesLibrary/Sources/Item/ItemSampleDataSeeder+PreviewSupport.swift
@@ -65,10 +65,10 @@ extension ItemSampleDataSeeder {
     static func paydayTemplate() -> PreviewItemTemplate {
         .init(
             day: .fourth,
-            content: String(localized: "Payday"),
+            content: String(localized: "Payday", table: "SampleData", bundle: .module),
             incomeBaseUSD: 4_500,
             outgoBaseUSD: 0,
-            category: String(localized: "Salary")
+            category: String(localized: "Salary", table: "SampleData", bundle: .module)
         )
     }
 
@@ -84,10 +84,10 @@ extension ItemSampleDataSeeder {
             paydayTemplate(),
             .init(
                 day: .fourth,
-                content: String(localized: "Advertising revenue"),
+                content: String(localized: "Advertising revenue", table: "SampleData", bundle: .module),
                 incomeBaseUSD: 500,
                 outgoBaseUSD: 0,
-                category: String(localized: "Salary")
+                category: String(localized: "Salary", table: "SampleData", bundle: .module)
             )
         ]
     }
@@ -96,24 +96,24 @@ extension ItemSampleDataSeeder {
         [
             .init(
                 day: .second,
-                content: String(localized: "Apple card"),
+                content: String(localized: "Apple card", table: "SampleData", bundle: .module),
                 incomeBaseUSD: 0,
                 outgoBaseUSD: 900,
-                category: String(localized: "Credit")
+                category: String(localized: "Credit", table: "SampleData", bundle: .module)
             ),
             .init(
                 day: .first,
-                content: String(localized: "Orange card"),
+                content: String(localized: "Orange card", table: "SampleData", bundle: .module),
                 incomeBaseUSD: 0,
                 outgoBaseUSD: 600,
-                category: String(localized: "Credit")
+                category: String(localized: "Credit", table: "SampleData", bundle: .module)
             ),
             .init(
                 day: .fourth,
-                content: String(localized: "Lemon card"),
+                content: String(localized: "Lemon card", table: "SampleData", bundle: .module),
                 incomeBaseUSD: 0,
                 outgoBaseUSD: 500,
-                category: String(localized: "Credit")
+                category: String(localized: "Credit", table: "SampleData", bundle: .module)
             )
         ]
     }
@@ -122,17 +122,17 @@ extension ItemSampleDataSeeder {
         [
             .init(
                 day: .fifth,
-                content: String(localized: "House"),
+                content: String(localized: "House", table: "SampleData", bundle: .module),
                 incomeBaseUSD: 0,
                 outgoBaseUSD: 1_800,
-                category: String(localized: "Loan")
+                category: String(localized: "Loan", table: "SampleData", bundle: .module)
             ),
             .init(
                 day: .third,
-                content: String(localized: "Car"),
+                content: String(localized: "Car", table: "SampleData", bundle: .module),
                 incomeBaseUSD: 0,
                 outgoBaseUSD: 300,
-                category: String(localized: "Loan")
+                category: String(localized: "Loan", table: "SampleData", bundle: .module)
             )
         ]
     }
@@ -141,17 +141,17 @@ extension ItemSampleDataSeeder {
         [
             .init(
                 day: .first,
-                content: String(localized: "Insurance"),
+                content: String(localized: "Insurance", table: "SampleData", bundle: .module),
                 incomeBaseUSD: 0,
                 outgoBaseUSD: 250,
-                category: String(localized: "Tax")
+                category: String(localized: "Tax", table: "SampleData", bundle: .module)
             ),
             .init(
                 day: .fifth,
-                content: String(localized: "Pension"),
+                content: String(localized: "Pension", table: "SampleData", bundle: .module),
                 incomeBaseUSD: 0,
                 outgoBaseUSD: 300,
-                category: String(localized: "Tax")
+                category: String(localized: "Tax", table: "SampleData", bundle: .module)
             )
         ]
     }

--- a/IncomesLibrary/Sources/Item/ItemSampleDataSeeder.swift
+++ b/IncomesLibrary/Sources/Item/ItemSampleDataSeeder.swift
@@ -96,10 +96,10 @@ enum ItemSampleDataSeeder {
                     context: context,
                     values: .init(
                         date: date,
-                        content: String(localized: "Pension"),
+                        content: String(localized: "Pension", table: "SampleData", bundle: .module),
                         income: LocaleAmountConverter.localizedAmount(baseUSD: 0),
                         outgo: LocaleAmountConverter.localizedAmount(baseUSD: 36),
-                        category: String(localized: "Tax"),
+                        category: String(localized: "Tax", table: "SampleData", bundle: .module),
                         priority: 0
                     ),
                     repeatID: .init()
@@ -143,10 +143,10 @@ enum ItemSampleDataSeeder {
             context: context,
             values: .init(
                 date: firstDate,
-                content: String(localized: "Salary"),
+                content: String(localized: "Salary", table: "SampleData", bundle: .module),
                 income: LocaleAmountConverter.localizedAmount(baseUSD: 3_000),
                 outgo: .zero,
-                category: String(localized: "Salary"),
+                category: String(localized: "Salary", table: "SampleData", bundle: .module),
                 priority: 0
             ),
             repeatID: .init()
@@ -157,10 +157,10 @@ enum ItemSampleDataSeeder {
             context: context,
             values: .init(
                 date: secondDate,
-                content: String(localized: "Rent"),
+                content: String(localized: "Rent", table: "SampleData", bundle: .module),
                 income: .zero,
                 outgo: LocaleAmountConverter.localizedAmount(baseUSD: 1_200),
-                category: String(localized: "Housing"),
+                category: String(localized: "Housing", table: "SampleData", bundle: .module),
                 priority: 0
             ),
             repeatID: .init()
@@ -171,10 +171,10 @@ enum ItemSampleDataSeeder {
             context: context,
             values: .init(
                 date: thirdDate,
-                content: String(localized: "Grocery"),
+                content: String(localized: "Grocery", table: "SampleData", bundle: .module),
                 income: .zero,
                 outgo: LocaleAmountConverter.localizedAmount(baseUSD: 45),
-                category: String(localized: "Food"),
+                category: String(localized: "Food", table: "SampleData", bundle: .module),
                 priority: 0
             ),
             repeatID: .init()
@@ -205,13 +205,38 @@ enum ItemSampleDataSeeder {
             TagMutationOperations.delete(tag: tag)
         }
     }
+
+    /// Seeds duplicate category tags for duplicate-tag previews.
+    static func seedDuplicateTagPreviewData(context: ModelContext) throws {
+        let previewDuplicateCount = 2
+        let duplicateCategoryName = String(localized: "Credit", table: "SampleData", bundle: .module)
+        let items = try ItemQueryOperations.items(context: context)
+        let sourceItems = items.filter { item in
+            item.category?.name == duplicateCategoryName
+        }
+
+        guard sourceItems.count >= previewDuplicateCount else {
+            return
+        }
+
+        for item in sourceItems.prefix(previewDuplicateCount) {
+            let duplicateTag = Tag.createIgnoringDuplicates(
+                context: context,
+                name: duplicateCategoryName,
+                type: .category
+            )
+            var tags = item.tags ?? []
+            tags.append(duplicateTag)
+            item.modify(tags: tags)
+        }
+    }
 }
 
 // swiftlint:enable no_magic_numbers
 
 private extension ItemSampleDataSeeder {
     static func attachSampleTag(to item: Item, context: ModelContext) throws {
-        let sampleName = String(localized: "Sample Data")
+        let sampleName = String(localized: "Sample Data", table: "SampleData", bundle: .module)
         let debugTag = try Tag.create(context: context, name: sampleName, type: .debug)
         var currentTags = item.tags ?? []
         currentTags.append(debugTag)

--- a/IncomesLibrary/Sources/Item/SampleDataOperations.swift
+++ b/IncomesLibrary/Sources/Item/SampleDataOperations.swift
@@ -50,6 +50,11 @@ public enum SampleDataOperations {
     public static func deleteDebugData(context: ModelContext) throws {
         try ItemSampleDataSeeder.deleteDebugData(context: context)
     }
+
+    /// Seeds duplicate category tags for duplicate-tag previews.
+    public static func seedDuplicateTagPreviewData(context: ModelContext) throws {
+        try ItemSampleDataSeeder.seedDuplicateTagPreviewData(context: context)
+    }
 }
 
 private extension SampleDataOperations.Profile {

--- a/IncomesLibrary/Tests/TimeZone/SampleDataOperationsTests.swift
+++ b/IncomesLibrary/Tests/TimeZone/SampleDataOperationsTests.swift
@@ -82,6 +82,21 @@ struct SampleDataOperationsTests {
         #expect(fetchItems(context).count == 1)
     }
 
+    @Test
+    func seedDuplicateTagPreviewData_creates_duplicate_category_tags() throws {
+        try SampleDataOperations.seed(
+            context: context,
+            profile: .preview,
+            baseDate: shiftedDate("2000-01-03T12:00:00Z"),
+            ifEmptyOnly: false
+        )
+        #expect(try SettingsStatusOperations.load(context: context).hasDuplicateTags == false)
+
+        try SampleDataOperations.seedDuplicateTagPreviewData(context: context)
+
+        #expect(try SettingsStatusOperations.load(context: context).hasDuplicateTags)
+    }
+
     // MARK: - Delete
 
     @Test


### PR DESCRIPTION
## Summary

- Move sample-data-only strings from the library `Localizable.xcstrings` into `SampleData.xcstrings`.
- Resolve sample data strings directly from the `SampleData` table at the seeding call sites.
- Move duplicate-tag preview seeding behind `SampleDataOperations` and cover it with a library test.

## Why

Sample data copy behaves more like fixture content than ordinary app UI text. Keeping it in a separate catalog makes that role explicit and allows future sample wording to diverge from normal UI localization when needed.

## Validation

- `bash ci_scripts/tasks/format_swift.sh`
- `python3 -m json.tool IncomesLibrary/Resources/Localizable.xcstrings`
- `python3 -m json.tool IncomesLibrary/Resources/SampleData.xcstrings`
- `python3 /private/tmp/audit_xcstrings_py39.py --project-root /Users/Hiromu/Repositories/Incomes --format json`
- `xcodebuild -quiet -scheme IncomesLibrary -project Incomes.xcodeproj -destination 'platform=iOS Simulator,id=4B96FE45-DAC9-416D-82FB-060B44B961D8' -derivedDataPath .build/DerivedData test`
- `xcodebuild -quiet -scheme Incomes -project Incomes.xcodeproj -destination 'platform=iOS Simulator,id=4B96FE45-DAC9-416D-82FB-060B44B961D8' -derivedDataPath .build/DerivedData build`
- `bash ci_scripts/tasks/check_repository_rules.sh`
- `git diff --check origin/main...HEAD`